### PR TITLE
Enhance Web browser support.

### DIFF
--- a/src/com/romraider/net/BrowserControl.java
+++ b/src/com/romraider/net/BrowserControl.java
@@ -21,6 +21,8 @@ package com.romraider.net;
 
 import org.apache.log4j.Logger;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
 
 public class BrowserControl {
     private static final Logger LOGGER = Logger.getLogger(BrowserControl.class);
@@ -30,6 +32,18 @@ public class BrowserControl {
     }
 
     public static void displayURL(String url) {
+        try {
+            Class<?> display = Class.forName("java.awt.Desktop");
+            Object getDesktopMethod = display.getDeclaredMethod("getDesktop").invoke(null);
+            Method browseMethod = display.getDeclaredMethod("browse", java.net.URI.class);
+            browseMethod.invoke(getDesktopMethod, new URI(url));
+        } catch (Exception e) {
+            LOGGER.debug("Failed to display URL via java.awt.Desktop. Calling by OS depended method.", e);
+            displayURLtraditional(url);
+        }
+    }
+
+    private static void displayURLtraditional(String url) {
         boolean windows = isWindowsPlatform();
         String cmd = null;
         try {


### PR DESCRIPTION
I think recent versions of Unices (like Linux) doesn't have Netscape browser.
I suggest to use java.awt.Desktop support.
Methods are called by reflection to make sure since some people runs RomRaider on JRE1.5 or below.
So it is kept the backward compatibility.

I tested this patch on OSX (10.6.7 / build 1.6.0_37-b06-434-10M3909).
