### PR TITLE
Resolves issue 22.

### DIFF
--- a/src/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/com/romraider/editor/ecu/ECUEditor.java
@@ -277,29 +277,29 @@ public class ECUEditor extends AbstractFrame {
 
     public void addRom(Rom input) {
         // add to ecu image list pane
-        RomTreeNode romNode = new RomTreeNode(input, settings.getUserLevel(), settings.isDisplayHighTables(), this);
-        imageRoot.add(romNode);
+        RomTreeNode romNode = new RomTreeNode(input, getSettings().getUserLevel(), getSettings().isDisplayHighTables(), this);
+        getImageRoot().add(romNode);
 
-        imageList.setVisible(true);
-        imageList.setRootVisible(true);
+        getImageList().setVisible(true);
+        getImageList().setRootVisible(true);
         TreePath addedRomPath = new TreePath(romNode.getPath());
-        imageList.expandPath(addedRomPath);
+        getImageList().expandPath(addedRomPath);
         // uncomment collapsePath if you want ROM to open collapsed.
         // imageList.collapsePath(addedRomPath);
-        imageList.setRootVisible(false);
-        imageList.repaint();
+        getImageList().setRootVisible(false);
+        getImageList().repaint();
 
         // Only set if no other rom has been selected.
         if(null == getLastSelectedRom()) {
             setLastSelectedRom(input);
         }
 
-        if (input.getRomID().isObsolete() && settings.isObsoleteWarning()) {
+        if (input.getRomID().isObsolete() && getSettings().isObsoleteWarning()) {
             JPanel infoPanel = new JPanel();
             infoPanel.setLayout(new GridLayout(3, 1));
             infoPanel.add(new JLabel("A newer version of this ECU revision exists. " +
                     "Please visit the following link to download the latest revision:"));
-            infoPanel.add(new URL(settings.getRomRevisionURL()));
+            infoPanel.add(new URL(getSettings().getRomRevisionURL()));
 
             JCheckBox check = new JCheckBox("Always display this message", true);
             check.setHorizontalAlignment(JCheckBox.RIGHT);
@@ -314,7 +314,7 @@ public class ECUEditor extends AbstractFrame {
             infoPanel.add(check);
             showMessageDialog(this, infoPanel, "ECU Revision is Obsolete", INFORMATION_MESSAGE);
         }
-        input.setContainer(this);
+        input.applyTableColorSettings();
     }
 
     public void displayTable(TableFrame frame) {
@@ -394,7 +394,7 @@ public class ECUEditor extends AbstractFrame {
         this.settings = settings;
         for (int i = 0; i < imageRoot.getChildCount(); i++) {
             RomTreeNode rtn = (RomTreeNode) imageRoot.getChildAt(i);
-            rtn.getRom().setContainer(this);
+            rtn.getRom().applyTableColorSettings();
         }
     }
 

--- a/src/com/romraider/maps/Rom.java
+++ b/src/com/romraider/maps/Rom.java
@@ -38,7 +38,6 @@ import javax.swing.JOptionPane;
 
 import org.apache.log4j.Logger;
 
-import com.romraider.editor.ecu.ECUEditor;
 import com.romraider.logger.ecu.ui.handler.table.TableUpdateHandler;
 import com.romraider.swing.JProgressPane;
 import com.romraider.xml.TableNotFoundException;
@@ -50,7 +49,6 @@ public class Rom implements Serializable {
     private String fileName = "";
     private File fullFileName = new File(".");
     private final Vector<Table> tables = new Vector<Table>();
-    private ECUEditor container;
     private byte[] binData;
     private String parent = "";
     private boolean isAbstract = false;
@@ -122,7 +120,7 @@ public class Rom implements Serializable {
                                 table.getStorageAddress() + " " + binData.length + " filesize", ex);
 
                         // table storage address extends beyond end of file
-                        JOptionPane.showMessageDialog(container, "Storage address for table \"" + table.getName() +
+                        JOptionPane.showMessageDialog(table.getEditor(), "Storage address for table \"" + table.getName() +
                                 "\" is out of bounds.\nPlease check ECU definition file.", "ECU Definition Error", JOptionPane.ERROR_MESSAGE);
                         tables.removeElementAt(i);
                         i--;
@@ -136,7 +134,7 @@ public class Rom implements Serializable {
                 }
 
             } catch (NullPointerException ex) {
-                JOptionPane.showMessageDialog(container, "There was an error loading table " + table.getName(), "ECU Definition Error", JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(table.getEditor(), "There was an error loading table " + table.getName(), "ECU Definition Error", JOptionPane.ERROR_MESSAGE);
                 tables.removeElementAt(i);
             }
         }
@@ -196,15 +194,9 @@ public class Rom implements Serializable {
         return tables;
     }
 
-    public ECUEditor getContainer() {
-        return container;
-    }
-
-    public void setContainer(ECUEditor container) {
-        this.container = container;
-        // apply settings to tables
+    public void applyTableColorSettings() {
         for (Table table : tables) {
-            table.applyColorSettings(container.getSettings());
+            table.applyColorSettings();
             //tables.get(i).resize();
             table.getFrame().pack();
         }
@@ -225,7 +217,7 @@ public class Rom implements Serializable {
             String message = String.format("One or more ROM image Checksums is invalid.  " +
                     "Calculate new Checksums?%n" +
                     "(NOTE: this will only fix the Checksums it will NOT repair a corrupt ROM image)");
-            int answer = showOptionDialog(container,
+            int answer = showOptionDialog(checksum.getEditor(),
                     message,
                     "Checksum Fix",
                     DEFAULT_OPTION,

--- a/src/com/romraider/maps/Table1D.java
+++ b/src/com/romraider/maps/Table1D.java
@@ -19,19 +19,22 @@
 
 package com.romraider.maps;
 
-import com.romraider.Settings;
-import javax.swing.JLabel;
 import java.awt.BorderLayout;
 import java.awt.Color;
+
+import javax.swing.JLabel;
+
+import com.romraider.editor.ecu.ECUEditor;
 
 public class Table1D extends Table {
     private static final long serialVersionUID = -8747180767803835631L;
     private Color axisColor = new Color(255, 255, 255);
 
-    public Table1D(Settings settings) {
-        super(settings);
+    public Table1D(ECUEditor editor) {
+        super(editor);
     }
 
+    @Override
     public void populateTable(byte[] input) {
         centerLayout.setRows(1);
         centerLayout.setColumns(this.getDataSize());
@@ -44,6 +47,7 @@ public class Table1D extends Table {
         add(new JLabel(name + " (" + scales.get(scaleIndex).getUnit() + ")", JLabel.CENTER), BorderLayout.NORTH);
     }
 
+    @Override
     public String toString() {
         return super.toString() + " (1D)";
     }
@@ -56,6 +60,7 @@ public class Table1D extends Table {
         this.isAxis = isAxis;
     }
 
+    @Override
     public void clearSelection() {
         super.clearSelection();
         //if (isAxis) axisParent.clearSelection();
@@ -69,10 +74,12 @@ public class Table1D extends Table {
         }
     }
 
+    @Override
     public void colorize() {
         super.colorize();
     }
 
+    @Override
     public void cursorUp() {
         if (type == Table.TABLE_Y_AXIS) {
             if (highlightY > 0 && data[highlightY].isSelected()) {
@@ -85,6 +92,7 @@ public class Table1D extends Table {
         }
     }
 
+    @Override
     public void cursorDown() {
         if (type == Table.TABLE_Y_AXIS) {
             if (axisParent.getType() == Table.TABLE_3D) {
@@ -103,6 +111,7 @@ public class Table1D extends Table {
         }
     }
 
+    @Override
     public void cursorLeft() {
         if (type == Table.TABLE_Y_AXIS) {
             // X axis is on left.. nothing happens
@@ -122,6 +131,7 @@ public class Table1D extends Table {
         }
     }
 
+    @Override
     public void cursorRight() {
         if (type == Table.TABLE_Y_AXIS && data[highlightY].isSelected()) {
             if (axisParent.getType() == Table.TABLE_3D) {
@@ -140,6 +150,7 @@ public class Table1D extends Table {
         }
     }
 
+    @Override
     public void startHighlight(int x, int y) {
         if (isAxis) {
             axisParent.clearSelection();
@@ -147,6 +158,7 @@ public class Table1D extends Table {
         super.startHighlight(x, y);
     }
 
+    @Override
     public StringBuffer getTableAsString() {
         StringBuffer output = new StringBuffer("");
         for (int i = 0; i < getDataSize(); i++) {
@@ -158,6 +170,7 @@ public class Table1D extends Table {
         return output;
     }
 
+    @Override
     public String getCellAsString(int index) {
         return data[index].getText();
     }
@@ -166,10 +179,12 @@ public class Table1D extends Table {
         return axisColor;
     }
 
+    @Override
     public void setAxisColor(Color axisColor) {
         this.axisColor = axisColor;
     }
 
+    @Override
     public void setLiveValue(String value) {
         liveValue = value;
         Table parent = getAxisParent();
@@ -178,10 +193,12 @@ public class Table1D extends Table {
         }
     }
 
+    @Override
     public boolean isLiveDataSupported() {
         return false;
     }
 
+    @Override
     public boolean isButtonSelected() {
         return true;
     }

--- a/src/com/romraider/maps/Table2D.java
+++ b/src/com/romraider/maps/Table2D.java
@@ -27,6 +27,7 @@ import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -39,19 +40,21 @@ import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 
 import com.romraider.Settings;
+import com.romraider.editor.ecu.ECUEditor;
 import com.romraider.swing.TableFrame;
 import com.romraider.util.AxisRange;
 
 public class Table2D extends Table {
     private static final long serialVersionUID = -7684570967109324784L;
     static final String NEW_LINE = System.getProperty("line.separator");
-    private Table1D axis = new Table1D(new Settings());
+    private Table1D axis;
 
     private CopyTable2DWorker copyTable2DWorker;
     private CopySelection2DWorker copySelection2DWorker;
 
-    public Table2D(Settings settings) {
-        super(settings);
+    public Table2D(ECUEditor editor) {
+        super(editor);
+        axis = new Table1D(editor);
         verticalOverhead += 18;
     }
 
@@ -96,10 +99,10 @@ public class Table2D extends Table {
     }
 
     @Override
-    public void applyColorSettings(Settings settings) {
-        this.setAxisColor(settings.getAxisColor());
-        axis.applyColorSettings(settings);
-        super.applyColorSettings(settings);
+    public void applyColorSettings() {
+        this.setAxisColor(editor.getSettings().getAxisColor());
+        axis.applyColorSettings();
+        super.applyColorSettings();
     }
 
     @Override
@@ -241,8 +244,12 @@ public class Table2D extends Table {
 
     @Override
     public void copySelection() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+        getEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        SwingUtilities.getWindowAncestor(this).setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         super.copySelection();
         copySelection2DWorker = new CopySelection2DWorker(this);
         copySelection2DWorker.execute();
@@ -250,9 +257,13 @@ public class Table2D extends Table {
 
     @Override
     public void copyTable() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+        getEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        SwingUtilities.getWindowAncestor(this).setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        copyTable2DWorker = new CopyTable2DWorker(settings, this);
+        copyTable2DWorker = new CopyTable2DWorker(editor.getSettings(), this);
         copyTable2DWorker.execute();
     }
 
@@ -402,8 +413,12 @@ class CopySelection2DWorker extends SwingWorker<Void, Void> {
 
     @Override
     public void done() {
-        SwingUtilities.getWindowAncestor(table).setCursor(null);
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(null);
+        }
         table.setCursor(null);
+        table.getEditor().setCursor(null);
     }
 }
 
@@ -433,7 +448,11 @@ class CopyTable2DWorker extends SwingWorker<Void, Void> {
 
     @Override
     public void done() {
-        SwingUtilities.getWindowAncestor(table).setCursor(null);
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(null);
+        }
         table.setCursor(null);
+        table.getEditor().setCursor(null);
     }
 }

--- a/src/com/romraider/maps/TableSwitch.java
+++ b/src/com/romraider/maps/TableSwitch.java
@@ -1,24 +1,24 @@
 /*
-* RomRaider Open-Source Tuning, Logging and Reflashing
-* Copyright (C) 2006-2012 RomRaider.com
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License along
-* with this program; if not, write to the Free Software Foundation, Inc.,
-* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
- 
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2012 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.romraider.maps;
- 
+
 import static com.romraider.maps.RomChecksum.validateRomChecksum;
 import static com.romraider.util.ByteUtil.indexOfBytes;
 import static com.romraider.util.HexUtil.asBytes;
@@ -43,32 +43,35 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JTextArea;
 
-import com.romraider.Settings;
+import com.romraider.editor.ecu.ECUEditor;
 
 public class TableSwitch extends Table {
- 
+
     private static final long serialVersionUID = -4887718305447362308L;
-    private ButtonGroup buttonGroup = new ButtonGroup();
-    private Map<String, byte[]> switchStates = new HashMap<String, byte[]>();
+    private final ButtonGroup buttonGroup = new ButtonGroup();
+    private final Map<String, byte[]> switchStates = new HashMap<String, byte[]>();
     private int dataSize = 0;
- 
-    public TableSwitch(Settings settings) {
-        super(settings);
+
+    public TableSwitch(ECUEditor editor) {
+        super(editor);
         storageType = 1;
         type = TABLE_SWITCH;
         locked = true;
         removeAll();
         setLayout(new BorderLayout());
     }
- 
+
+    @Override
     public void setDataSize(int size) {
         if (dataSize == 0) dataSize = size;
     }
- 
+
+    @Override
     public int getDataSize() {
         return dataSize;
     }
 
+    @Override
     public void populateTable(byte[] input) {
         JPanel radioPanel = new JPanel(new GridLayout(0, 1));
         radioPanel.add(new JLabel("  " + name));
@@ -78,7 +81,7 @@ public class TableSwitch extends Table {
             radioPanel.add(button);
         }
         add(radioPanel, BorderLayout.CENTER);
-       
+
         // Validate the ROM image checksums.
         // if the result is >0: position of failed checksum
         // if the result is  0: all the checksums matched
@@ -87,8 +90,8 @@ public class TableSwitch extends Table {
             int result = validateRomChecksum(input, storageAddress, dataSize);
             String message = String.format(
                     "Checksum No. %d is invalid.%n" +
-                    "The ROM image may be corrupt.%n" +
-                    "Use of this ROM image is not advised!", result);
+                            "The ROM image may be corrupt.%n" +
+                            "Use of this ROM image is not advised!", result);
             if (result > 0) {
                 showMessageDialog(this,
                         message,
@@ -143,21 +146,24 @@ public class TableSwitch extends Table {
         if (locked) {
             String mismatch = String.format("Table: %s%nTable editing has been disabled.%nDefinition file or ROM image may be corrupt.", super.getName());
             showMessageDialog(this,
-                              mismatch,
-                              "ERROR - Data Mismatch",
-                              ERROR_MESSAGE);
+                    mismatch,
+                    "ERROR - Data Mismatch",
+                    ERROR_MESSAGE);
             setButtonsUnselected(buttonGroup);
         }
     }
- 
+
+    @Override
     public void setName(String name) {
         super.setName(name);
     }
- 
+
+    @Override
     public int getType() {
         return TABLE_SWITCH;
     }
- 
+
+    @Override
     public void setDescription(String description) {
         super.setDescription(description);
         JTextArea descriptionArea = new JTextArea(description);
@@ -166,10 +172,11 @@ public class TableSwitch extends Table {
         descriptionArea.setWrapStyleWord(true);
         descriptionArea.setLineWrap(true);
         descriptionArea.setMargin(new Insets(0,5,5,5));
- 
+
         add(descriptionArea, BorderLayout.SOUTH);
     }
- 
+
+    @Override
     public byte[] saveFile(byte[] input) {
         if (!super.getName().equalsIgnoreCase("Checksum Fix")) {
             if (!locked) {
@@ -184,15 +191,16 @@ public class TableSwitch extends Table {
         }
         return input;
     }
- 
+
     public void setValues(String name, String input) {
         switchStates.put(name, asBytes(input));
     }
- 
+
     public byte[] getValues(String key) {
-            return switchStates.get(key);
+        return switchStates.get(key);
     }
- 
+
+    @Override
     public Dimension getFrameSize() {
         int height = verticalOverhead + 75;
         int width = horizontalOverhead;
@@ -205,29 +213,37 @@ public class TableSwitch extends Table {
         }
         return new Dimension(width, height);
     }
- 
+
+    @Override
     public void colorize() {
     }
- 
+
+    @Override
     public void cursorUp() {
     }
- 
+
+    @Override
     public void cursorDown() {
     }
- 
+
+    @Override
     public void cursorLeft() {
     }
- 
+
+    @Override
     public void cursorRight() {
     }
- 
+
+    @Override
     public void setAxisColor(Color color) {
     }
- 
+
+    @Override
     public boolean isLiveDataSupported() {
         return false;
     }
- 
+
+    @Override
     public boolean isButtonSelected() {
         if (buttonGroup.getSelection() == null) {
             return false;
@@ -247,7 +263,7 @@ public class TableSwitch extends Table {
         }
         return null;
     }
- 
+
     // Unselects & disables all radio buttons in the specified group
     private static void setButtonsUnselected(ButtonGroup group) {
         for (Enumeration<AbstractButton> e = group.getElements(); e.hasMoreElements(); ) {
@@ -256,7 +272,7 @@ public class TableSwitch extends Table {
             b.setEnabled(false);
         }
     }
- 
+
     // returns the radio button based on its display text
     private static JRadioButton getButtonByText(ButtonGroup group, String text) {
         for (Enumeration<AbstractButton> e = group.getElements(); e.hasMoreElements(); ) {

--- a/src/com/romraider/swing/JTableChooser.java
+++ b/src/com/romraider/swing/JTableChooser.java
@@ -19,18 +19,20 @@
 
 package com.romraider.swing;
 
-import com.romraider.maps.Rom;
-import com.romraider.maps.Table;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTree;
-import javax.swing.tree.DefaultMutableTreeNode;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.Vector;
+
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTree;
+import javax.swing.tree.DefaultMutableTreeNode;
+
+import com.romraider.maps.Rom;
+import com.romraider.maps.Table;
 
 public class JTableChooser extends JOptionPane implements MouseListener {
 
@@ -40,7 +42,6 @@ public class JTableChooser extends JOptionPane implements MouseListener {
     JTree displayTree = new JTree(rootNode);
 
     public boolean showChooser(Vector<Rom> roms, Component parent, Table targetTable) {
-
         int nameLength = 0;
         for (int i = 0; i < roms.size(); i++) {
             Rom rom = roms.get(i);
@@ -74,7 +75,7 @@ public class JTableChooser extends JOptionPane implements MouseListener {
             }
         }
 
-        displayTree.setPreferredSize(new Dimension(nameLength*7, 400));  
+        displayTree.setPreferredSize(new Dimension(nameLength*7, 400));
         displayTree.setMinimumSize(new Dimension(nameLength*7, 400));
 
         displayTree.setRootVisible(true);
@@ -84,8 +85,9 @@ public class JTableChooser extends JOptionPane implements MouseListener {
 
         Object[] values = {"Compare", "Cancel"};
 
-        if ((showOptionDialog(parent, displayPanel, "Select a Map", JOptionPane.DEFAULT_OPTION, JOptionPane.PLAIN_MESSAGE, null, values, values[0]) == 0 &&
-                (displayTree.getLastSelectedPathComponent() instanceof TableChooserTreeNode))) {
+        if ((showOptionDialog(parent, displayPanel, "Select a Map", JOptionPane.DEFAULT_OPTION,
+                JOptionPane.PLAIN_MESSAGE, null, values, values[0]) == 0
+                && (displayTree.getLastSelectedPathComponent() instanceof TableChooserTreeNode))) {
             ((TableChooserTreeNode) displayTree.getLastSelectedPathComponent()).getTable().copyTable();
             return true;
         } else {
@@ -93,13 +95,18 @@ public class JTableChooser extends JOptionPane implements MouseListener {
         }
     }
 
+    @Override
     public void mouseReleased(MouseEvent e) {
         displayTree.setPreferredSize(new Dimension(displayTree.getWidth(), (displayTree.getRowCount()*displayTree.getRowHeight())));
         displayTree.revalidate();
     }
+    @Override
     public void mouseClicked(MouseEvent e){}
+    @Override
     public void mouseEntered(MouseEvent e){}
+    @Override
     public void mouseExited(MouseEvent e){}
+    @Override
     public void mousePressed(MouseEvent e){}
 
 }

--- a/src/com/romraider/swing/RomCellRenderer.java
+++ b/src/com/romraider/swing/RomCellRenderer.java
@@ -19,9 +19,14 @@
 
 package com.romraider.swing;
 
-import com.romraider.maps.Rom;
-import com.romraider.maps.Table;
 import static javax.swing.BorderFactory.createLineBorder;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.GridLayout;
+
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -29,11 +34,9 @@ import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeCellRenderer;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GridLayout;
+
+import com.romraider.maps.Rom;
+import com.romraider.maps.Table;
 
 public class RomCellRenderer implements TreeCellRenderer {
 
@@ -52,9 +55,10 @@ public class RomCellRenderer implements TreeCellRenderer {
 
     }
 
+    @Override
     public Component getTreeCellRendererComponent(JTree tree, Object value,
-                                                  boolean selected, boolean expanded, boolean leaf, int row,
-                                                  boolean hasFocus) {
+            boolean selected, boolean expanded, boolean leaf, int row,
+            boolean hasFocus) {
 
         Component returnValue = null;
 
@@ -79,7 +83,7 @@ public class RomCellRenderer implements TreeCellRenderer {
                         rom.getRomID().getModel() + " " +
                         rom.getRomID().getSubModel() + ", " +
                         rom.getRomID().getTransmission()
-                );
+                        );
 
                 JPanel renderer = new JPanel(new GridLayout(2, 1));
                 renderer.add(fileName);
@@ -132,7 +136,7 @@ public class RomCellRenderer implements TreeCellRenderer {
                 tableName.setForeground(new Color(255, 150, 150));
                 tableName.setFont(new Font("Tahoma", Font.ITALIC, 11));
 
-            } else if (table.getUserLevel() > table.getRom().getContainer().getSettings().getUserLevel()) {
+            } else if (table.getUserLevel() > table.getEditor().getSettings().getUserLevel()) {
                 //tableName.setForeground(new Color(185, 185, 185));
                 tableName.setFont(new Font("Tahoma", Font.ITALIC, 11));
 

--- a/src/com/romraider/swing/TableFrame.java
+++ b/src/com/romraider/swing/TableFrame.java
@@ -58,7 +58,7 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener 
 
     @Override
     public void internalFrameActivated(InternalFrameEvent e) {
-        getTable().getRom().getContainer().setLastSelectedRom(getTable().getRom());
+        getTable().getEditor().setLastSelectedRom(getTable().getRom());
         parent.updateTableToolBar(this.table);
         parent.getToolBar().updateButtons();
         parent.getEditorMenuBar().updateMenu();
@@ -72,7 +72,7 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener 
 
     @Override
     public void internalFrameClosing(InternalFrameEvent e) {
-        getTable().getRom().getContainer().removeDisplayTable(this);
+        getTable().getEditor().removeDisplayTable(this);
     }
 
     @Override

--- a/src/com/romraider/swing/TableMenuBar.java
+++ b/src/com/romraider/swing/TableMenuBar.java
@@ -19,7 +19,9 @@
 
 package com.romraider.swing;
 
-import com.romraider.maps.Table;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
 import javax.swing.ButtonGroup;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -27,38 +29,38 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JSeparator;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+
+import com.romraider.maps.Table;
 
 public class TableMenuBar extends JMenuBar implements ActionListener {
 
     private static final long serialVersionUID = -695692646459410510L;
-    private Table table;
-    private JMenu fileMenu = new JMenu("Table");
-    private JMenuItem graph = new JMenuItem("View Graph");
+    private final Table table;
+    private final JMenu fileMenu = new JMenu("Table");
+    private final JMenuItem graph = new JMenuItem("View Graph");
     //private JRadioButtonMenuItem overlay = new JRadioButtonMenuItem("Overlay Log");
 
-    private JMenu compareMenu = new JMenu("Compare");
-    private JRadioButtonMenuItem compareOriginal = new JRadioButtonMenuItem("Show Changes");
-    private JRadioButtonMenuItem compareMap = new JRadioButtonMenuItem("Compare to Another Map");
-    private JRadioButtonMenuItem compareOff = new JRadioButtonMenuItem("Off");
-    private JMenu compareDisplay = new JMenu("Display");
-    private JRadioButtonMenuItem comparePercent = new JRadioButtonMenuItem("Percent Difference");
-    private JRadioButtonMenuItem compareAbsolute = new JRadioButtonMenuItem("Absolute Difference");
+    private final JMenu compareMenu = new JMenu("Compare");
+    private final JRadioButtonMenuItem compareOriginal = new JRadioButtonMenuItem("Show Changes");
+    private final JRadioButtonMenuItem compareMap = new JRadioButtonMenuItem("Compare to Another Map");
+    private final JRadioButtonMenuItem compareOff = new JRadioButtonMenuItem("Off");
+    private final JMenu compareDisplay = new JMenu("Display");
+    private final JRadioButtonMenuItem comparePercent = new JRadioButtonMenuItem("Percent Difference");
+    private final JRadioButtonMenuItem compareAbsolute = new JRadioButtonMenuItem("Absolute Difference");
 
-    private JMenuItem close = new JMenuItem("Close Table");
-    private JMenu editMenu = new JMenu("Edit");
-    private JMenuItem undoSel = new JMenuItem("Undo Selected Changes");
-    private JMenuItem undoAll = new JMenuItem("Undo All Changes");
-    private JMenuItem revert = new JMenuItem("Set Revert Point");
-    private JMenuItem copySel = new JMenuItem("Copy Selection");
-    private JMenuItem copyTable = new JMenuItem("Copy Table");
-    private JMenuItem paste = new JMenuItem("Paste");
-    private JMenu viewMenu = new JMenu("View");
-    private JMenuItem tableProperties = new JMenuItem("Table Properties");
+    private final JMenuItem close = new JMenuItem("Close Table");
+    private final JMenu editMenu = new JMenu("Edit");
+    private final JMenuItem undoSel = new JMenuItem("Undo Selected Changes");
+    private final JMenuItem undoAll = new JMenuItem("Undo All Changes");
+    private final JMenuItem revert = new JMenuItem("Set Revert Point");
+    private final JMenuItem copySel = new JMenuItem("Copy Selection");
+    private final JMenuItem copyTable = new JMenuItem("Copy Table");
+    private final JMenuItem paste = new JMenuItem("Paste");
+    private final JMenu viewMenu = new JMenu("View");
+    private final JMenuItem tableProperties = new JMenuItem("Table Properties");
 
-    private ButtonGroup compareGroup = new ButtonGroup();
-    private ButtonGroup compareDisplayGroup = new ButtonGroup();
+    private final ButtonGroup compareGroup = new ButtonGroup();
+    private final ButtonGroup compareDisplayGroup = new ButtonGroup();
 
     public TableMenuBar(Table table) {
         this.table = table;
@@ -139,6 +141,7 @@ public class TableMenuBar extends JMenuBar implements ActionListener {
         graph.setEnabled(false);
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         if (e.getSource() == undoAll) {
             table.undoAll();
@@ -150,7 +153,7 @@ public class TableMenuBar extends JMenuBar implements ActionListener {
             table.undoSelected();
 
         } else if (e.getSource() == close) {
-            table.getRom().getContainer().removeDisplayTable(table.getFrame());
+            table.getEditor().removeDisplayTable(table.getFrame());
 
         } else if (e.getSource() == tableProperties) {
             JOptionPane.showMessageDialog(table, new TablePropertyPanel(table),
@@ -173,7 +176,7 @@ public class TableMenuBar extends JMenuBar implements ActionListener {
 
         } else if (e.getSource() == compareMap) {
             JTableChooser chooser = new JTableChooser();
-            if (chooser.showChooser(table.getRom().getContainer().getImages(), table.getRom().getContainer(), table)) {
+            if (chooser.showChooser(table.getEditor().getImages(), table.getEditor(), table)) {
                 table.pasteCompare();
                 table.compare(Table.COMPARE_TABLE);
             }

--- a/src/com/romraider/xml/DOMRomUnmarshaller.java
+++ b/src/com/romraider/xml/DOMRomUnmarshaller.java
@@ -21,6 +21,20 @@
 
 package com.romraider.xml;
 
+import static com.romraider.xml.DOMHelper.unmarshallAttribute;
+import static com.romraider.xml.DOMHelper.unmarshallText;
+import static org.w3c.dom.Node.ELEMENT_NODE;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.management.modelmbean.XMLParseException;
+import javax.swing.JOptionPane;
+
+import org.apache.log4j.Logger;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditor;
 import com.romraider.maps.DataCell;
@@ -36,23 +50,13 @@ import com.romraider.swing.DebugPanel;
 import com.romraider.swing.JProgressPane;
 import com.romraider.util.LogManager;
 import com.romraider.util.ObjectCloner;
-import static com.romraider.xml.DOMHelper.unmarshallAttribute;
-import static com.romraider.xml.DOMHelper.unmarshallText;
-import org.apache.log4j.Logger;
-import org.w3c.dom.Node;
-import static org.w3c.dom.Node.ELEMENT_NODE;
-import org.w3c.dom.NodeList;
-import javax.management.modelmbean.XMLParseException;
-import javax.swing.JOptionPane;
-import java.util.ArrayList;
-import java.util.List;
 
 public final class DOMRomUnmarshaller {
     private static final Logger LOGGER = Logger.getLogger(DOMRomUnmarshaller.class);
     private JProgressPane progress = null;
-    private List<Scale> scales = new ArrayList<Scale>();
-    private Settings settings;
-    private ECUEditor parent;
+    private final List<Scale> scales = new ArrayList<Scale>();
+    private final Settings settings;
+    private final ECUEditor parent;
 
     public DOMRomUnmarshaller(Settings settings, ECUEditor parent) {
         this.settings = settings;
@@ -323,7 +327,7 @@ public final class DOMRomUnmarshaller {
 
         if (!unmarshallAttribute(tableNode, "base", "none").equalsIgnoreCase("none")) { // copy base table for inheritance
             try {
-                table = (Table) ObjectCloner.deepCopy((Object) rom.getTable(unmarshallAttribute(tableNode, "base", "none")));
+                table = (Table) ObjectCloner.deepCopy(rom.getTable(unmarshallAttribute(tableNode, "base", "none")));
 
             } catch (TableNotFoundException ex) { /* table not found, do nothing */
 
@@ -339,24 +343,24 @@ public final class DOMRomUnmarshaller {
             }
         } catch (NullPointerException ex) { // if type is null or less than 0, create new instance (otherwise it is inherited)
             if (unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("3D")) {
-                table = new Table3D(settings);
+                table = new Table3D(parent);
 
             } else if (unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("2D")) {
-                table = new Table2D(settings);
+                table = new Table2D(parent);
 
             } else if (unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("1D")) {
-                table = new Table1D(settings);
+                table = new Table1D(parent);
 
             } else if (unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("X Axis") ||
                     unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("Y Axis")) {
-                table = new Table1D(settings);
+                table = new Table1D(parent);
 
             } else if (unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("Static Y Axis") ||
                     unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("Static X Axis")) {
-                table = new Table1D(settings);
+                table = new Table1D(parent);
 
             } else if (unmarshallAttribute(tableNode, "type", "unknown").equalsIgnoreCase("Switch")) {
-                table = new TableSwitch(settings);
+                table = new TableSwitch(parent);
 
             } else {
                 throw new XMLParseException("Error loading table, " + tableNode.getAttributes().getNamedItem("name"));


### PR DESCRIPTION
- Removed reference to ECUEditor from ROM.
  - Removed reference to Settings and added ECUEditor to Table.  Table is
    now constructed with an ECUEditor instead Settings.
  - Added check for null returned from
    SwingUtilities.getWindowAncestor().  This may be unecessary now that we
    have access to the ECUEditor object.
  - Resolved ArrayIndexOutOfBoundsException when using the arrow key to
    move left(past the first element -1) in a Table.
