### PR TITLE
Remove redndant checkNotNullOrEmpry().

### DIFF
--- a/src/com/romraider/io/protocol/ssm/SSMProtocol.java
+++ b/src/com/romraider/io/protocol/ssm/SSMProtocol.java
@@ -58,14 +58,12 @@ public final class SSMProtocol implements Protocol {
     private final PollingState pollState = new PollingStateImpl();
     
     public byte[] constructEcuInitRequest(byte id) {
-        checkNotNullOrEmpty(String.valueOf(id), "ECU_ID");
         SSMProtocol.ECU_ID = id;
         // 0x80 0x10 0xF0 0x01 0xBF 0x40
         return buildRequest(ECU_INIT_COMMAND, false, new byte[0]);
     }
 
     public byte[] constructWriteMemoryRequest(byte id, byte[] address, byte[] values) {
-        checkNotNullOrEmpty(String.valueOf(id), "ECU_ID");
         checkNotNullOrEmpty(address, "address");
         checkNotNullOrEmpty(values, "values");
         SSMProtocol.ECU_ID = id;
@@ -81,7 +79,6 @@ public final class SSMProtocol implements Protocol {
     }
 
     public byte[] constructReadMemoryRequest(byte id, byte[] address, int numBytes) {
-        checkNotNullOrEmpty(String.valueOf(id), "ECU_ID");
         checkNotNullOrEmpty(address, "address");
         checkGreaterThanZero(numBytes, "numBytes");
         SSMProtocol.ECU_ID = id;
@@ -90,7 +87,6 @@ public final class SSMProtocol implements Protocol {
     }
 
     public byte[] constructReadAddressRequest(byte id, byte[][] addresses) {
-        checkNotNullOrEmpty(String.valueOf(id), "ECU_ID");
         checkNotNullOrEmpty(addresses, "addresses");
         SSMProtocol.ECU_ID = id;
         // 0x80 0x10 0xF0 data_length 0xA8 padding address1 address2 ... addressN checksum
@@ -124,7 +120,6 @@ public final class SSMProtocol implements Protocol {
     public byte[] constructEcuResetRequest(byte id) {
         //  80 10 F0 05 B8 00 00 60 40 DD
         //FIXME: Create a buildWriteAddressRequest() method
-        checkNotNullOrEmpty(String.valueOf(id), "ECU_ID");
         SSMProtocol.ECU_ID = id;
         byte[] resetDataBytes = new byte[]{(byte) 0x00, (byte) 0x00, (byte) 0x60, (byte) 0x40};
         return buildRequest(WRITE_ADDRESS_COMMAND, false, resetDataBytes);


### PR DESCRIPTION
 String.valueOf(int) will not return null or empty string.
