### PR TITLE
float is always little endian

### DIFF
--- a/src/main/java/com/romraider/xml/RomAttributeParser.java
+++ b/src/main/java/com/romraider/xml/RomAttributeParser.java
@@ -196,6 +196,8 @@ public final class RomAttributeParser {
         ByteBuffer bb = ByteBuffer.wrap(input, 0, 4);
         if (endian == Settings.ENDIAN_LITTLE) {
             bb.order(ByteOrder.BIG_ENDIAN);
+        } else {
+            bb.order(ByteOrder.LITTLE_ENDIAN);
         }
         return bb.getFloat();
     }


### PR DESCRIPTION
table endian="big" does not currently work, my change contains the fix

here is a debugger screenshot before the change:
http://i.imgur.com/LggzMFJ.png
note how value is same for ENDIAN_LITTLE = 1 and for ENDIAN_BIG = 2

here is the same spot with my fix:
http://i.imgur.com/1IVS01a.png
1.2 is the expected value from my bin