### PR TITLE
Improving user input and multiply bug

### DIFF
--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -120,7 +120,8 @@ public class DataCell extends JLabel implements MouseListener, Serializable {
             double result = 0.0;
             if (!"x".equalsIgnoreCase(input)) {
 				result = JEPUtil.evaluate(table.getCurrentScale().getByteExpression(), NumberUtil.doubleValue(input));
-                if (table.getStorageType() != Settings.STORAGE_TYPE_FLOAT) {
+
+				if (table.getStorageType() != Settings.STORAGE_TYPE_FLOAT) {
                     result = (int) Math.round(result);
                 }
 
@@ -508,7 +509,12 @@ public class DataCell extends JLabel implements MouseListener, Serializable {
     }
     
     public void multiply(double factor) {
-    	setRealValue((getRealValue() * factor) + "");
+    	String newValue = (getRealValue() * factor) + "";
+    	
+    	//We need to convert from dot to comma, in the case of EU Format. This is because getRealValue to String has dot notation.
+    	if(NumberUtil.getSeperator() == ',') newValue = newValue.replace('.', ',');
+    	
+    	setRealValue(newValue);
     }
     
     //Used to be multiply(), this doesn't work as expected on negative values though

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2016 RomRaider.com
+ * Copyright (C) 2006-2017 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -506,8 +506,13 @@ public class DataCell extends JLabel implements MouseListener, Serializable {
             this.compareToValue = compareCell.originalValue;
         }
     }
-
+    
     public void multiply(double factor) {
+    	setRealValue((getRealValue() * factor) + "");
+    }
+    
+    //Used to be multiply(), this doesn't work as expected on negative values though
+    public void multiplyRaw(double factor) {
         setBinValue(binValue * factor);
     }
 

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -945,10 +945,16 @@ public abstract class Table extends JPanel implements Serializable {
     }
 
     public void multiply(double factor) {
+    	
         if (!locked && !(userLevel > getSettings().getUserLevel())) {
             for (DataCell cell : data) {
                 if (cell.isSelected()) {
-                    cell.multiply(factor);
+                	
+                	//Use raw or real value, depending on view settings
+                	if(getCurrentScale().getName().equals("Default"))
+                		cell.multiply(factor);                	
+                	else 
+                		cell.multiplyRaw(factor);               	
                 }
             }
         } else if (userLevel > getSettings().getUserLevel()) {

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -949,12 +949,13 @@ public abstract class Table extends JPanel implements Serializable {
         if (!locked && !(userLevel > getSettings().getUserLevel())) {
             for (DataCell cell : data) {
                 if (cell.isSelected()) {
+                	System.out.println(getCurrentScale().getName());
                 	
                 	//Use raw or real value, depending on view settings
-                	if(getCurrentScale().getName().equals("Default"))
-                		cell.multiply(factor);                	
+                	if(getCurrentScale().getName().equals("Raw Value"))
+                		cell.multiplyRaw(factor);                	
                 	else 
-                		cell.multiplyRaw(factor);               	
+                		cell.multiply(factor);               	
                 }
             }
         } else if (userLevel > getSettings().getUserLevel()) {

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -949,7 +949,6 @@ public abstract class Table extends JPanel implements Serializable {
         if (!locked && !(userLevel > getSettings().getUserLevel())) {
             for (DataCell cell : data) {
                 if (cell.isSelected()) {
-                	System.out.println(getCurrentScale().getName());
                 	
                 	//Use raw or real value, depending on view settings
                 	if(getCurrentScale().getName().equals("Raw Value"))

--- a/src/main/java/com/romraider/maps/Table1D.java
+++ b/src/main/java/com/romraider/maps/Table1D.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2016 RomRaider.com
+ * Copyright (C) 2006-2017 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -439,7 +439,7 @@ public class Table3D extends Table {
             for (int x = 0; x < this.getSizeX(); x++) {
                 for (int y = 0; y < this.getSizeY(); y++) {
                     if (data[x][y].isSelected()) {
-                    	System.out.println(getCurrentScale().getName());
+                    	
                     	if(getCurrentScale().getName().equals("Raw Value"))
                     		data[x][y].multiplyRaw(factor);                	
                     	else 

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -439,10 +439,11 @@ public class Table3D extends Table {
             for (int x = 0; x < this.getSizeX(); x++) {
                 for (int y = 0; y < this.getSizeY(); y++) {
                     if (data[x][y].isSelected()) {
-                    	if(getCurrentScale().getName().equals("Default"))
-                    		data[x][y].multiply(factor);                	
+                    	System.out.println(getCurrentScale().getName());
+                    	if(getCurrentScale().getName().equals("Raw Value"))
+                    		data[x][y].multiplyRaw(factor);                	
                     	else 
-                    		data[x][y].multiplyRaw(factor);                            
+                    		data[x][y].multiply(factor);                            
                     }
                 }
             }

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -439,7 +439,10 @@ public class Table3D extends Table {
             for (int x = 0; x < this.getSizeX(); x++) {
                 for (int y = 0; y < this.getSizeY(); y++) {
                     if (data[x][y].isSelected()) {
-                        data[x][y].multiply(factor);
+                    	if(getCurrentScale().getName().equals("Default"))
+                    		data[x][y].multiply(factor);                	
+                    	else 
+                    		data[x][y].multiplyRaw(factor);                            
                     }
                 }
             }

--- a/src/main/java/com/romraider/swing/ECUEditorNumberField.java
+++ b/src/main/java/com/romraider/swing/ECUEditorNumberField.java
@@ -1,0 +1,59 @@
+package com.romraider.swing;
+
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.text.DecimalFormat;
+import javax.swing.JFormattedTextField;
+
+public class ECUEditorNumberField extends JFormattedTextField {
+	private static final long serialVersionUID = 4756399956045598977L;
+	
+	static DecimalFormat format = new DecimalFormat("#.####");
+	
+	public ECUEditorNumberField(){
+		super(format);
+		
+        format.setMinimumFractionDigits(0);
+        format.setMaximumFractionDigits(4);
+		
+		this.addKeyListener(new KeyListener(){
+
+			  public void keyTyped(KeyEvent e) {
+			    char c = e.getKeyChar();
+				
+			    //Replace , with .
+			     if (c== ',')
+			       e.setKeyChar('.');
+			     
+			     String textValue = ECUEditorNumberField.this.getText();
+			     int dotCount = textValue.length() - textValue.replace(".", "").length();
+			     
+			     //Only allow one dot
+			     if(e.getKeyChar()== '.' && dotCount == 1){
+			    	e.consume();		    
+			     }
+			     
+			     //dash can only be the first char
+			     if(e.getKeyChar()== '-' && ECUEditorNumberField.this.getCaretPosition() != 0){
+			    	e.consume();		    
+			     }
+			     
+			     //Only allow numbers
+			     else if(!(c >= '0' && c <= '9') && e.getKeyChar()!= '.' && e.getKeyChar()!= '-') e.consume();
+
+			  }
+
+			@Override
+			public void keyPressed(KeyEvent arg0) {	
+			}
+			@Override
+			public void keyReleased(KeyEvent arg0) {	
+			}
+		});
+
+	}
+	
+
+}

--- a/src/main/java/com/romraider/swing/ECUEditorNumberField.java
+++ b/src/main/java/com/romraider/swing/ECUEditorNumberField.java
@@ -24,6 +24,8 @@ import java.awt.event.KeyListener;
 import java.text.DecimalFormat;
 import javax.swing.JFormattedTextField;
 
+import com.romraider.util.NumberUtil;
+
 public class ECUEditorNumberField extends JFormattedTextField {
 	private static final long serialVersionUID = 4756399956045598977L;
 	
@@ -39,21 +41,24 @@ public class ECUEditorNumberField extends JFormattedTextField {
 
 			  public void keyTyped(KeyEvent e) {
 			    char c = e.getKeyChar();
-				
-			    //Replace , with .
-			     if (c== ',')
-			       e.setKeyChar('.');
+							    
+			    //Get separator for the defined locale
+			    char seperator = NumberUtil.getSeperator();
+			    
+			    //Replace , with . or vice versa
+			    if ((c == ',' || c == '.') && seperator != c)
+			      e.setKeyChar(seperator);			    
+			     			     
+			    ECUEditorNumberField field = ECUEditorNumberField.this;
 			     
-			     ECUEditorNumberField field = ECUEditorNumberField.this;
+			    String textValue = field.getText();
+			    int dotCount = textValue.length() - textValue.replace(seperator + "", "").length();
 			     
-			     String textValue = field.getText();
-			     int dotCount = textValue.length() - textValue.replace(".", "").length();
+			    //Only allow one dot
+			    if(e.getKeyChar() == seperator && (dotCount == 0 || field.getSelectionStart() == 0)) return;
 			     
-			     //Only allow one dot
-			     if(e.getKeyChar()== '.' && (dotCount == 0 || field.getSelectionStart() == 0)) return;
-			     
-			     //Only one dash allowed at the start
-			     else if(e.getKeyChar()== '-' && (field.getCaretPosition() == 0 || field.getSelectionStart() == 0)) return;
+			    //Only one dash allowed at the start
+			    else if(e.getKeyChar()== '-' && (field.getCaretPosition() == 0 || field.getSelectionStart() == 0)) return;
 			     
 			     //Only allow numbers
 			     else if(c >= '0' && c <= '9') return;

--- a/src/main/java/com/romraider/swing/ECUEditorNumberField.java
+++ b/src/main/java/com/romraider/swing/ECUEditorNumberField.java
@@ -44,22 +44,22 @@ public class ECUEditorNumberField extends JFormattedTextField {
 			     if (c== ',')
 			       e.setKeyChar('.');
 			     
-			     String textValue = ECUEditorNumberField.this.getText();
+			     ECUEditorNumberField field = ECUEditorNumberField.this;
+			     
+			     String textValue = field.getText();
 			     int dotCount = textValue.length() - textValue.replace(".", "").length();
 			     
 			     //Only allow one dot
-			     if(e.getKeyChar()== '.' && dotCount == 1){
-			    	e.consume();		    
-			     }
+			     if(e.getKeyChar()== '.' && (dotCount == 0 || field.getSelectionStart() == 0)) return;
 			     
-			     //dash can only be the first char
-			     if(e.getKeyChar()== '-' && ECUEditorNumberField.this.getCaretPosition() != 0){
-			    	e.consume();		    
-			     }
+			     //Only one dash allowed at the start
+			     else if(e.getKeyChar()== '-' && (field.getCaretPosition() == 0 || field.getSelectionStart() == 0)) return;
 			     
 			     //Only allow numbers
-			     else if(!(c >= '0' && c <= '9') && e.getKeyChar()!= '.' && e.getKeyChar()!= '-') e.consume();
-
+			     else if(c >= '0' && c <= '9') return;
+			     
+			     //Don't allow if input doesn't meet these rules
+			     else e.consume();			    
 			  }
 
 			@Override

--- a/src/main/java/com/romraider/swing/ECUEditorNumberField.java
+++ b/src/main/java/com/romraider/swing/ECUEditorNumberField.java
@@ -1,7 +1,24 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2017 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.romraider.swing;
 
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.text.DecimalFormat;

--- a/src/main/java/com/romraider/swing/SettingsForm.java
+++ b/src/main/java/com/romraider/swing/SettingsForm.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2012 RomRaider.com
+ * Copyright (C) 2006-2017 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/swing/SettingsForm.java
+++ b/src/main/java/com/romraider/swing/SettingsForm.java
@@ -21,12 +21,15 @@ package com.romraider.swing;
 
 import static com.romraider.Version.PRODUCT_NAME;
 import static java.io.File.separator;
+import static javax.swing.JOptionPane.INFORMATION_MESSAGE;
+import static javax.swing.JOptionPane.showMessageDialog;
 
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.io.File;
+import java.util.Locale;
 import java.util.StringTokenizer;
 
 import javax.swing.*;
@@ -85,6 +88,8 @@ public class SettingsForm extends JFrame implements MouseListener {
     private void initSettings() {
         Settings settings = getSettings();
         obsoleteWarning.setSelected(settings.isObsoleteWarning());
+        oldLocale = settings.getLocale();
+        localeFormatCheckBox.setSelected(oldLocale.equals("en_US"));
         calcConflictWarning.setSelected(settings.isCalcConflictWarning());
         displayHighTables.setSelected(settings.isDisplayHighTables());
         saveDebugTables.setSelected(settings.isSaveDebugTables());
@@ -154,6 +159,7 @@ public class SettingsForm extends JFrame implements MouseListener {
     private void initComponents() {
         obsoleteWarning = new javax.swing.JCheckBox();
         calcConflictWarning = new javax.swing.JCheckBox();
+        localeFormatCheckBox = new javax.swing.JCheckBox();
         debug = new javax.swing.JCheckBox();
         btnCancel = new javax.swing.JButton();
         btnOk = new javax.swing.JButton();
@@ -219,14 +225,19 @@ public class SettingsForm extends JFrame implements MouseListener {
         setTitle(PRODUCT_NAME + " Settings");
         setCursor(new java.awt.Cursor(java.awt.Cursor.DEFAULT_CURSOR));
         setFont(new java.awt.Font("Tahoma", 0, 12));
+        
         obsoleteWarning.setText("Warn me when opening out of date ECU image revision");
         obsoleteWarning.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         obsoleteWarning.setMargin(new java.awt.Insets(0, 0, 0, 0));
 
+        localeFormatCheckBox.setText("Use US English number format (Dot Notation)");
+        localeFormatCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
+        localeFormatCheckBox.setMargin(new java.awt.Insets(0, 0, 0, 0));
+        
         calcConflictWarning.setText("Warn me when real and byte value calculations conflict");
         calcConflictWarning.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         calcConflictWarning.setMargin(new java.awt.Insets(0, 0, 0, 0));
-
+        
         debug.setText("Debug mode");
         debug.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         debug.setEnabled(false);
@@ -532,6 +543,7 @@ public class SettingsForm extends JFrame implements MouseListener {
                                 .addComponent(panelUISettings, GroupLayout.DEFAULT_SIZE, 407, Short.MAX_VALUE)
                                 .addComponent(obsoleteWarning)
                                 .addComponent(calcConflictWarning)
+                                .addComponent(localeFormatCheckBox)
                                 .addComponent(debug))
                                 .addContainerGap())
                 );
@@ -542,6 +554,8 @@ public class SettingsForm extends JFrame implements MouseListener {
                         .addComponent(obsoleteWarning)
                         .addPreferredGap(ComponentPlacement.RELATED)
                         .addComponent(calcConflictWarning)
+                        .addPreferredGap(ComponentPlacement.RELATED)
+                        .addComponent(localeFormatCheckBox)
                         .addPreferredGap(ComponentPlacement.RELATED)
                         .addComponent(debug)
                         .addPreferredGap(ComponentPlacement.RELATED)
@@ -943,11 +957,26 @@ public class SettingsForm extends JFrame implements MouseListener {
         try {
             Integer.parseInt(cellWidth.getText());
         } catch (NumberFormatException ex) {
-            // number formatted imporperly, reset
+            // number formatted improperly, reset
             cellWidth.setText((int) (getSettings().getCellSize().getWidth()) + "");
         }
 
         getSettings().setObsoleteWarning(obsoleteWarning.isSelected());
+
+        //Apply locale settings
+        if (localeFormatCheckBox.isSelected()) 
+            getSettings().setLocale("en_US");       
+        else 
+            getSettings().setLocale("system");
+        
+        //Show Info if locale changed
+        if(!oldLocale.equals(getSettings().getLocale())){
+        showMessageDialog(this, "The Editor has been set to use the " +
+                getSettings().getLocale() + " number format.\n\n" +
+                "Exit and restart the Editor to apply the new setting.",
+                "Editor Number Format Change", INFORMATION_MESSAGE);
+        }
+        
         getSettings().setCalcConflictWarning(calcConflictWarning.isSelected());
         getSettings().setDisplayHighTables(displayHighTables.isSelected());
         getSettings().setSaveDebugTables(saveDebugTables.isSelected());
@@ -1131,4 +1160,6 @@ public class SettingsForm extends JFrame implements MouseListener {
     private javax.swing.JTextField defaultScale;
     private javax.swing.JComboBox comboBoxDefaultScale;
     private javax.swing.JCheckBox cbScaleHeaderAndData;
+    private javax.swing.JCheckBox localeFormatCheckBox;
+    private String oldLocale;
 }

--- a/src/main/java/com/romraider/swing/TableToolBar.java
+++ b/src/main/java/com/romraider/swing/TableToolBar.java
@@ -36,7 +36,6 @@ import java.awt.event.MouseListener;
 import java.beans.PropertyVetoException;
 import java.math.BigDecimal;
 import java.net.URL;
-import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.util.Vector;
 
@@ -49,7 +48,6 @@ import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
-import javax.swing.JFormattedTextField;
 import javax.swing.JInternalFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -89,9 +87,9 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     private final JButton setValue = new JButton("Set");
     private final JButton multiply = new JButton("Mul");
 
-    private final JFormattedTextField incrementByFine = new JFormattedTextField(new DecimalFormat("#.####"));
-    private final JFormattedTextField incrementByCoarse = new JFormattedTextField(new DecimalFormat("#.####"));
-    private final JFormattedTextField setValueText = new JFormattedTextField(new DecimalFormat("#.####"));
+    private final ECUEditorNumberField incrementByFine = new ECUEditorNumberField();
+    private final ECUEditorNumberField incrementByCoarse = new ECUEditorNumberField();
+    private final ECUEditorNumberField setValueText = new ECUEditorNumberField();
 
     private final JComboBox scaleSelection = new JComboBox();
 

--- a/src/main/java/com/romraider/swing/TableToolBar.java
+++ b/src/main/java/com/romraider/swing/TableToolBar.java
@@ -514,6 +514,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         try{
             currentTable.multiply(NumberUtil.doubleValue(setValueText.getText()));
         }catch(ParseException nex) {
+        	System.out.println(this.getClass().getName() + ".multiply(" + currentTable + ") " + nex);
             LOGGER.error(this.getClass().getName() + ".multiply(" + currentTable + ") " + nex);
         }
     }

--- a/src/main/java/com/romraider/swing/TableToolBar.java
+++ b/src/main/java/com/romraider/swing/TableToolBar.java
@@ -514,7 +514,6 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         try{
             currentTable.multiply(NumberUtil.doubleValue(setValueText.getText()));
         }catch(ParseException nex) {
-        	System.out.println(this.getClass().getName() + ".multiply(" + currentTable + ") " + nex);
             LOGGER.error(this.getClass().getName() + ".multiply(" + currentTable + ") " + nex);
         }
     }

--- a/src/main/java/com/romraider/util/NumberUtil.java
+++ b/src/main/java/com/romraider/util/NumberUtil.java
@@ -36,7 +36,15 @@ public final class NumberUtil {
 
     private NumberUtil() {
     }
-
+    
+    /**
+     * Returns the separator based on the current locale (. or ,)
+     * @return  The separation character
+     */
+    public static char getSeperator(){
+    	return ((DecimalFormat) NUM_FORMATTER).getDecimalFormatSymbols().getDecimalSeparator();
+    }
+    
     /**
      * Returns the value of the specified number in the default locale as a double.
      * @param   str - string to be converted.

--- a/src/main/java/com/romraider/util/NumberUtil.java
+++ b/src/main/java/com/romraider/util/NumberUtil.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2016 RomRaider.com
+ * Copyright (C) 2006-2017 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hi,
while I used RR I noticed a bug when multiplying negative values, you can find the thread here:
http://www.romraider.com/forum/viewtopic.php?f=5&t=13789
It now uses the real representation, instead of the raw value.

I also restricted the user input for the set/multiply fields, so that they don't even allow invalid input while typing. If you type in an invalid value in the current version, the cell gets set to 0 most of the time. Commas also get converted to dots by default now.