### PR TITLE
Bitwise toggle map

### DIFF
--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -1,0 +1,185 @@
+package com.romraider.maps;
+
+import java.awt.BorderLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+
+import com.romraider.Settings;
+import static com.romraider.util.ByteUtil.isBitSet;
+
+public class TableBitwiseSwitch extends Table {
+
+    private static final long serialVersionUID = -4887718305447362308L;
+    private final Map<String, Integer> controlBits = new HashMap<String, Integer>();
+    private ArrayList<JCheckBox> checkboxes;
+    
+    public TableBitwiseSwitch() {
+        super();
+        storageType = 1;
+        type = Settings.TABLE_SWITCH;
+        locked = true;
+        removeAll();
+        setLayout(new BorderLayout());
+        checkboxes = new ArrayList<JCheckBox>();
+    }
+
+    @Override
+    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
+        byte currentValue = input[storageAddress];
+    	JPanel radioPanel = new JPanel(new GridLayout(0, 1));
+        radioPanel.add(new JLabel("  " + getName()));
+        for (Entry<String, Integer> entry: controlBits.entrySet()) {
+            JCheckBox cb = new JCheckBox(entry.getKey());
+            cb.setSelected(isBitSet(currentValue, entry.getValue()));
+            checkboxes.add(cb);
+            radioPanel.add(cb);
+        }
+        add(radioPanel, BorderLayout.CENTER);
+    }
+
+    @Override
+    public void setName(String name) {
+        super.setName(name);
+    }
+
+    @Override
+    public int getType() {
+        return Settings.TABLE_SWITCH;
+    }
+
+    @Override
+    public void setDescription(String description) {
+        super.setDescription(description);
+        JTextArea descriptionArea = new JTextArea(description);
+        descriptionArea.setOpaque(false);
+        descriptionArea.setEditable(false);
+        descriptionArea.setWrapStyleWord(true);
+        descriptionArea.setLineWrap(true);
+        descriptionArea.setMargin(new Insets(0,5,5,5));
+
+        add(descriptionArea, BorderLayout.SOUTH);
+    }
+
+    @Override
+    public byte[] saveFile(byte[] input) {
+    	
+    	boolean[] bools = new boolean[8];
+    	for (Entry<String, Integer> entry: controlBits.entrySet()) {
+    		JCheckBox cb = getButtonByText(entry.getKey());
+    		bools[entry.getValue()] = cb.isSelected();
+    	}
+    	
+    	int bits = 0;
+    	for (int i = 0; i < bools.length; i++) {
+    	    if (bools[i])
+    	        bits |= 1 << i;
+    	}
+    	
+    	input[storageAddress] = (byte) bits;
+        return input;
+    }
+
+    public void setValues(String name, String input) {
+        controlBits.put(name, Integer.parseInt(input));
+    }
+
+    public int getValues(String key) {
+        return controlBits.get(key);
+    }
+
+    public Map<String, Integer> getSwitchStates() {
+        return this.controlBits;
+    }
+
+    @Override
+    public void cursorUp() {
+    }
+
+    @Override
+    public void cursorDown() {
+    }
+
+    @Override
+    public void cursorLeft() {
+    }
+
+    @Override
+    public void cursorRight() {
+    }
+
+	@Override
+	public void shiftCursorUp() {
+	}
+
+	@Override
+	public void shiftCursorDown() {
+	}
+
+	@Override
+	public void shiftCursorLeft() {
+	}
+
+	@Override
+	public void shiftCursorRight() {
+	}
+
+    @Override
+    public boolean isLiveDataSupported() {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+    	return false;
+    }
+
+    @Override
+    public void populateCompareValues(Table compareTable) {
+        return; // Do nothing.
+    }
+
+    @Override
+    public void calcCellRanges() {
+        return; // Do nothing.
+    }
+
+    @Override
+    public void drawTable()
+    {
+        return; // Do nothing.
+    }
+
+    @Override
+    public void updateTableLabel() {
+        return; // Do nothing.
+    }
+
+    @Override
+    public void setCurrentScale(Scale curScale) {
+        return; // Do nothing.
+    }
+
+	@Override
+	public boolean isButtonSelected() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+	
+    private JCheckBox getButtonByText(String text) {
+    	for (JCheckBox cb : checkboxes) {
+    		if (cb.getText().equalsIgnoreCase(text)) {
+    			return cb;
+    		}
+    	}
+        return null;
+    }
+}

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -26,7 +26,6 @@ public class TableBitwiseSwitch extends Table {
         super();
         storageType = 1;
         type = Settings.TABLE_SWITCH;
-        locked = true;
         removeAll();
         setLayout(new BorderLayout());
         checkboxes = new ArrayList<JCheckBox>();
@@ -139,7 +138,40 @@ public class TableBitwiseSwitch extends Table {
 
     @Override
     public boolean equals(Object other) {
-    	return false;
+    	try {
+            if(null == other) {
+                return false;
+            }
+
+            if(other == this) {
+                return true;
+            }
+
+            if(!(other instanceof TableSwitch)) {
+                return false;
+            }
+
+            TableBitwiseSwitch otherTable = (TableBitwiseSwitch) other;
+
+            if( (null == this.getName() && null == otherTable.getName())
+                    || (this.getName().isEmpty() && otherTable.getName().isEmpty()) ) {
+                ;// Skip name compare if name is null or empty.
+            } else if(!this.getName().equalsIgnoreCase(otherTable.getName())) {
+                return false;
+            }
+
+            if(this.getDataSize() != otherTable.getDataSize()) {
+                return false;
+            }
+
+            if(this.getSwitchStates().keySet().equals(otherTable.getSwitchStates().keySet())) {
+                return true;
+            }
+            return false;
+    	} catch(Exception ex) {
+            // TODO: Log Exception.
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -147,7 +147,7 @@ public class TableBitwiseSwitch extends Table {
                 return true;
             }
 
-            if(!(other instanceof TableSwitch)) {
+            if(!(other instanceof TableBitwiseSwitch)) {
                 return false;
             }
 

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -1,3 +1,22 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2018 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
 package com.romraider.maps;
 
 import java.awt.BorderLayout;

--- a/src/main/java/com/romraider/util/ByteUtil.java
+++ b/src/main/java/com/romraider/util/ByteUtil.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2013 RomRaider.com
+ * Copyright (C) 2006-2018 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/util/ByteUtil.java
+++ b/src/main/java/com/romraider/util/ByteUtil.java
@@ -100,6 +100,9 @@ public final class ByteUtil {
         }
         return -1;
     }
+    public static boolean isBitSet(byte b, int position) {
+    	return (b & 1 << position) != 0;
+    }
 
     private static int[] computeFailure(byte[] pattern) {
         int[] failure = new int[pattern.length];
@@ -115,4 +118,5 @@ public final class ByteUtil {
         }
         return failure;
     }
+    
 }

--- a/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2017 RomRaider.com
+ * Copyright (C) 2006-2018 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
@@ -47,6 +47,7 @@ import com.romraider.maps.Table;
 import com.romraider.maps.Table1D;
 import com.romraider.maps.Table2D;
 import com.romraider.maps.Table3D;
+import com.romraider.maps.TableBitwiseSwitch;
 import com.romraider.maps.TableSwitch;
 import com.romraider.maps.checksum.ChecksumFactory;
 import com.romraider.maps.checksum.ChecksumManager;
@@ -415,6 +416,10 @@ public final class DOMRomUnmarshaller {
                         .equalsIgnoreCase("Switch")) {
                     table = new TableSwitch();
 
+                } else if (unmarshallAttribute(tableNode, "type", "unknown")
+                        .equalsIgnoreCase("BitwiseSwitch")) {
+                    table = new TableBitwiseSwitch();
+
                 } else {
                     throw new XMLParseException("Error loading table, "
                             + tableNode.getAttributes().getNamedItem("name"));
@@ -581,6 +586,11 @@ public final class DOMRomUnmarshaller {
                     ((TableSwitch) table).setValues(
                             unmarshallAttribute(n, "name", ""),
                             unmarshallAttribute(n, "data", "0.0"));
+
+                } else if (n.getNodeName().equalsIgnoreCase("bit")) {
+                    ((TableBitwiseSwitch) table).setValues(
+                            unmarshallAttribute(n, "name", ""),
+                            unmarshallAttribute(n, "position", "0"));
 
                 } else { /* unexpected element in Table (skip) */
                 }


### PR DESCRIPTION
Added new map option that allows toggling of individual bits in each byte. Following definition should be followed to declare switchable bits:

```
<table type="BitwiseSwitch" name="WhatThisByteControls" storageaddress="0xbyteaddress">
  <description>What this byte's bits control should go here..</description>
  <bit position="0" name="TheUseOfThisBit"/>
  <bit position="7" name="AnotherControlBit"/>
</table>
```