### PR TITLE
Minor build system updates

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
 <!-- Master build file for RomRaider
 
  RomRaider Open-Source Tuning, Logging and Reflashing
- Copyright (C) 2006-2013 RomRaider.com
+ Copyright (C) 2006-2018 RomRaider.com
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/build.xml
+++ b/build.xml
@@ -24,7 +24,7 @@
 <project name="romraider" default="help" basedir=".">
 
     <!-- get the environment -->
-    <property environment="env"/>
+    <property environment="env" />
 
     <!-- =================================================================== -->
     <!-- Help                                                                -->
@@ -32,129 +32,122 @@
     <!--   with common property overrides                                    -->
     <!-- =================================================================== -->
     <target name="help" depends="-init">
-        <echo message="help        [Print this message                     ]"/>
-        <echo message="clean       [Clean generated files                  ]"/>
-        <echo message="prepare     [Create directories for output files    ]"/>
-        <echo message="            [  and generate files from templates    ]"/>
-        <echo message="build       [Compile the Java source files          ]"/>
-        <echo message="rebuild     [Call the clean and build targets       ]"/>
-        <echo message="javadoc     [Generate the API documentation of the  ]"/>
-        <echo message="            [Java source code                       ]"/>
-        <echo message="dist        [Create the distribution packages       ]"/>
-        <echo message="all         [Complete rebuild and packaging         ]"/>
+        <echo message="help        [Print this message                     ]" />
+        <echo message="clean       [Clean generated files                  ]" />
+        <echo message="prepare     [Create directories for output files    ]" />
+        <echo message="            [  and generate files from templates    ]" />
+        <echo message="build       [Compile the Java source files          ]" />
+        <echo message="rebuild     [Call the clean and build targets       ]" />
+        <echo message="javadoc     [Generate the API documentation of the  ]" />
+        <echo message="            [Java source code                       ]" />
+        <echo message="dist        [Create the distribution packages       ]" />
+        <echo message="all         [Complete rebuild and packaging         ]" />
     </target>
 
     <!-- =================================================================== -->
     <!-- Initialization target - only callable internally                    -->
     <!-- =================================================================== -->
     <target name="-init" unless="initialized">
-        <property name="initialized" value="true"/>
+        <property name="initialized" value="true" />
         <!-- set the various timestamp properties we may need -->
         <tstamp>
-            <format property="time.rfc822" pattern="EEE, dd MMM yyyy HH:mm:ss Z"/>
-            <format property="time.year" pattern="yyyy"/>
+            <format property="time.rfc822" pattern="EEE, dd MMM yyyy HH:mm:ss Z" />
+            <format property="time.year" pattern="yyyy" />
         </tstamp>
 
         <!-- set os specific properties -->
-        <property name="os.windows" value="windows"/>
-        <property name="ext.windows" value="bat"/>
-        <property name="os.linux" value="linux"/>
-        <property name="ext.linux" value="sh"/>
+        <property name="os.windows" value="windows" />
+        <property name="ext.windows" value="bat" />
+        <property name="os.linux" value="linux" />
+        <property name="ext.linux" value="sh" />
 
         <condition property="os" value="${os.windows}" else="${os.linux}">
-            <os family="windows"/>
+            <os family="windows" />
         </condition>
 
         <condition property="is.windows">
-            <equals arg1="${os}" arg2="${os.windows}"/>
+            <equals arg1="${os}" arg2="${os.windows}" />
         </condition>
 
-        <property name="izpack.compile.${os.windows}" value="compile.bat"/>
-        <property name="izpack.compile.${os.linux}" value="compile"/>
+        <property name="izpack.compile.${os.windows}" value="compile.bat" />
+        <property name="izpack.compile.${os.linux}" value="compile" />
 
         <!-- java compiler properties -->
-        <property name="debug" value="off"/>
-        <property name="optimize" value="on"/>
-        <property name="deprecation" value="on"/>
-
-        <!-- get the current svn revision (needed by version.properties) - if repository is unavailable, this will be zero 
-        <macro_svn_revision repository="https://svn2.assembla.com/svn/romraider" property="svn.revision"/> -->
-
-        <!-- Set the buildnumber to be the revision fetched from the repository, but default to zero for
-                offline work -->
-        <condition property="buildnumber" value="${svn.revision}" else="0">
-            <isset property="svn.revision"/>
-        </condition>
+        <property name="javac.source" value="1.6" />
+        <property name="javac.target" value="1.6" />
+    	<property name="debug" value="off" />
+        <property name="deprecation" value="on" />
 
     	<!-- version properties are set in this file, both for the product itself and
 		        for some of the external dependencies (jar files and such) -->
-        <property file="version.properties"/>
+        <property file="version.properties" />
 
         <!-- basic project properties -->
-        <property name="src.dir" value="${basedir}/src"/>
-        <property name="src.java.dir" value="${src.dir}/main/java"/>
-        <property name="src.res.dir" value="${src.dir}/main/resources"/>
-        <property name="graphics.dir" value="${src.res.dir}/graphics"/>
-        <property name="docs.dir" value="${basedir}/docs"/>
-        <property name="build.dir" value="${basedir}/build"/>
-        <property name="template.dir" value="${basedir}/templates"/>
-        <property name="3rdparty.dir" value="${basedir}/3rdparty"/>
+        <property name="src.dir" value="${basedir}/src" />
+        <property name="src.java.dir" value="${src.dir}/main/java" />
+        <property name="src.res.dir" value="${src.dir}/main/resources" />
+        <property name="graphics.dir" value="${src.res.dir}/graphics" />
+        <property name="docs.dir" value="${basedir}/docs" />
+        <property name="build.dir" value="${basedir}/build" />
+        <property name="template.dir" value="${basedir}/templates" />
+        <property name="3rdparty.dir" value="${basedir}/3rdparty" />
 
         <!-- all generated files should go to somewhere in the build directory -->
-        <property name="classes.dir" value="${build.dir}/classes"/>
-        <property name="javadoc.dir" value="${build.dir}/javadoc"/>
-        <property name="dist.dir" value="${build.dir}/dist"/>
+        <property name="classes.dir" value="${build.dir}/classes" />
+        <property name="javadoc.dir" value="${build.dir}/javadoc" />
+        <property name="dist.dir" value="${build.dir}/dist" />
 
         <!-- package naming properties -->
-        <property name="jar.package" value="${name.package}.jar"/>
+        <property name="jar.package" value="${name.package}.jar" />
         <property name="jar.installer-prefix"
-                  value="${name.package}${version.major}.${version.minor}.${version.patch}-${version.buildnumber}"/>
+                  value="${name.package}${version.major}.${version.minor}.${version.patch}-${version.buildnumber}" />
 
         <!-- support tools -->
         <!-- creates EXE wrappers around java apps -->
-        <property name="launch4j.dir" location="${3rdparty.dir}/launch4j"/>
+        <property name="launch4j.dir" location="${3rdparty.dir}/launch4j" />
         <!-- installer packager -->
-        <property name="izpack.dir" value="${3rdparty.dir}/IzPack"/>
+        <property name="izpack.dir" value="${3rdparty.dir}/IzPack" />
 
         <!-- define custom tasks -->
         <taskdef name="launch4j" classname="net.sf.launch4j.ant.Launch4jTask"
-                 classpath="${launch4j.dir}/launch4j.jar:${launch4j.dir}/lib/xstream.jar"/>
+                 classpath="${launch4j.dir}/launch4j.jar:${launch4j.dir}/lib/xstream.jar" />
 
         <!-- windows classpath -->
         <path id="windows.classpath">
-            <fileset dir="lib/common" includes="*.jar"/>
-            <fileset dir="lib/windows" includes="*.jar"/>
+            <fileset dir="lib/common" includes="*.jar" />
+            <fileset dir="lib/windows" includes="*.jar" />
         </path>
 
         <!-- linux classpath -->
         <path id="linux.classpath">
-            <fileset dir="lib/common" includes="*.jar"/>
-            <fileset dir="lib/linux" includes="*.jar"/>
+            <fileset dir="lib/common" includes="*.jar" />
+            <fileset dir="lib/linux" includes="*.jar" />
         </path>
 
         <!-- this set of filters should contain all the substitutions needed -->
         <filterset id="version.filterset">
-            <filter token="warning.generated-file" value="${warning.generated-file}"/>
-            <filter token="name.package" value="${name.package}"/>
-            <filter token="description.package" value="${description.package}"/>
-            <filter token="name.organization" value="${name.organization}"/>
-            <filter token="name.maintainer" value="${name.maintainer}"/>
-            <filter token="email.maintainer" value="${email.maintainer}"/>
-            <filter token="supporturl" value="${supporturl}"/>
-            <filter token="romrevisionurl" value="${romrevisionurl}"/>
-            <filter token="ecudefsurl" value="${ecudefsurl}"/>
-            <filter token="loggerdefsurl" value="${loggerdefsurl}"/>
-            <filter token="carsdefsurl" value="${carsdefsurl}"/>
-            <filter token="release_notes" value="${release_notes}"/>
-            <filter token="version.major" value="${version.major}"/>
-            <filter token="version.minor" value="${version.minor}"/>
-            <filter token="version.patch" value="${version.patch}"/>
-            <filter token="version.buildnumber" value="${version.buildnumber}"/>
-            <filter token="version.extra" value="${version.extra}"/>
-            <filter token="version.extra1" value="${version.extra1}"/>
-            <filter token="min.logger.def.version" value="${min.logger.def.version}"/>
-            <filter token="jvm.args.win" value="${jvm.args.win}"/>
-            <filter token="jvm.args.linux" value="${jvm.args.linux}"/>
+            <filter token="time.year" value="${time.year}" />
+            <filter token="warning.generated-file" value="${warning.generated-file}" />
+            <filter token="name.package" value="${name.package}" />
+            <filter token="description.package" value="${description.package}" />
+            <filter token="name.organization" value="${name.organization}" />
+            <filter token="name.maintainer" value="${name.maintainer}" />
+            <filter token="email.maintainer" value="${email.maintainer}" />
+            <filter token="supporturl" value="${supporturl}" />
+            <filter token="romrevisionurl" value="${romrevisionurl}" />
+            <filter token="ecudefsurl" value="${ecudefsurl}" />
+            <filter token="loggerdefsurl" value="${loggerdefsurl}" />
+            <filter token="carsdefsurl" value="${carsdefsurl}" />
+            <filter token="release_notes" value="${release_notes}" />
+            <filter token="version.major" value="${version.major}" />
+            <filter token="version.minor" value="${version.minor}" />
+            <filter token="version.patch" value="${version.patch}" />
+            <filter token="version.buildnumber" value="${version.buildnumber}" />
+            <filter token="version.extra" value="${version.extra}" />
+            <filter token="version.extra1" value="${version.extra1}" />
+            <filter token="min.logger.def.version" value="${min.logger.def.version}" />
+            <filter token="jvm.args.win" value="${jvm.args.win}" />
+            <filter token="jvm.args.linux" value="${jvm.args.linux}" />
         </filterset>
     </target>
 
@@ -162,7 +155,7 @@
     <!-- cleans all generated files                                          -->
     <!-- =================================================================== -->
     <target name="clean" depends="-init">
-        <delete dir="${build.dir}" failonerror="false"/>
+        <delete dir="${build.dir}" failonerror="false" />
     </target>
 
     <!-- =================================================================== -->
@@ -172,38 +165,38 @@
         <!-- generate the Version class -->
         <copy overwrite="true" tofile="${src.java.dir}/com/romraider/Version.java"
               file="src/main/java/com/romraider/Version.java.template">
-            <filterset refid="version.filterset"/>
+            <filterset refid="version.filterset" />
         </copy>
     </target>
 
     <!-- =================================================================== -->
     <!-- complete rebuild                                                    -->
     <!-- =================================================================== -->
-    <target name="rebuild" depends="clean, build"/>
+    <target name="rebuild" depends="clean, build" />
 
     <!-- =================================================================== -->
     <!-- Compiles the source directory                                       -->
     <!-- =================================================================== -->
     <target name="build" depends="prepare">
-        <macro_compile os="${os.windows}"/>
-        <macro_jar os="${os.windows}"/>
-        <macro_jar os="${os.linux}"/>
+        <macro_compile os="${os.windows}" />
+        <macro_jar os="${os.windows}" />
+        <macro_jar os="${os.linux}" />
     </target>
 
     <!-- ================================================================== -->
     <!-- generate javadoc                                                   -->
     <!-- ================================================================== -->
     <target name="javadoc" depends="-init">
-        <delete quiet="true" dir="${javadoc.dir}"/>
-        <mkdir dir="${javadoc.dir}"/>
+        <delete quiet="true" dir="${javadoc.dir}" />
+        <mkdir dir="${javadoc.dir}" />
         <javadoc windowtitle="${name.package}" header="${javadoc.header}" sourcepath="${src.java.dir}" author="yes"
                  version="yes" destdir="${javadoc.dir}"
                  breakiterator="yes" maxmemory="96m">
             <packageset dir="src">
-                <include name="**"/>
+                <include name="**" />
             </packageset>
             <bottom>${javadoc.footer}</bottom>
-            <classpath refid="${os.windows}.classpath"/>
+            <classpath refid="${os.windows}.classpath" />
         </javadoc>
     </target>
 
@@ -211,153 +204,142 @@
     <!-- create distribution                                                 -->
     <!-- =================================================================== -->
     <target name="dist" depends="-init">
-        <delete dir="${dist.dir}" failonerror="false"/>
-        <mkdir dir="${dist.dir}/windows"/>
-        <mkdir dir="${dist.dir}/linux"/>
+        <delete dir="${dist.dir}" failonerror="false" />
+        <mkdir dir="${dist.dir}/windows" />
+        <mkdir dir="${dist.dir}/linux" />
         <!-- generate installer scripts from templates -->
         <copy overwrite="true" tofile="${dist.dir}/install-windows.xml"
               file="${template.dir}/install-windows.xml.template">
-            <filterset refid="version.filterset"/>
+            <filterset refid="version.filterset" />
         </copy>
         <copy overwrite="true" tofile="${dist.dir}/install-linux.xml" file="${template.dir}/install-linux.xml.template">
-            <filterset refid="version.filterset"/>
+            <filterset refid="version.filterset" />
         </copy>
         <copy overwrite="true" tofile="${dist.dir}/shortcutSpec-windows.xml"
               file="${template.dir}/shortcutSpec-windows.xml.template">
-            <filterset refid="version.filterset"/>
+            <filterset refid="version.filterset" />
         </copy>
         <copy overwrite="true" tofile="${dist.dir}/shortcutSpec-linux.xml"
               file="${template.dir}/shortcutSpec-linux.xml.template">
-            <filterset refid="version.filterset"/>
+            <filterset refid="version.filterset" />
         </copy>
         <!-- generate the launch4j scripts from templates -->
         <copy overwrite="true" tofile="${dist.dir}/l4j-installer.xml" file="${template.dir}/l4j-installer.xml.template">
-            <filterset refid="version.filterset"/>
+            <filterset refid="version.filterset" />
         </copy>
         <copy overwrite="true" tofile="${dist.dir}/l4j-package.xml" file="${template.dir}/l4j-package.xml.template">
-            <filterset refid="version.filterset"/>
+            <filterset refid="version.filterset" />
         </copy>
 
         <macro_generate_executables/>
 
-        <macro_standalone os="${os.windows}"/>
-        <macro_standalone os="${os.linux}"/>
+        <macro_standalone os="${os.windows}" />
+        <macro_standalone os="${os.linux}" />
     </target>
 
     <!-- =================================================================== -->
     <!-- all                                                                 -->
     <!-- =================================================================== -->
-    <target name="all" depends="rebuild, dist"/>
+    <target name="all" depends="rebuild, dist" />
 
     <!-- =================================================================== -->
     <!-- Macros                                                              -->
     <!-- =================================================================== -->
-    <macrodef name="macro_svn_revision">
-        <attribute name="revision" default="HEAD"/>
-        <attribute name="repository"/>
-        <attribute name="property"/>
-        <sequential>
-            <tempfile property="svninfo.log"/>
-            <exec executable="git" output="${svninfo.log}" failonerror="false">
-                <arg line="describe --always"/>
-            </exec>
-            <loadfile property="@{property}" srcFile="${svninfo.log}">
-                <filterchain>
-                    <linecontainsregexp>
-                        <regexp pattern="Last Changed Rev: "/>
-                    </linecontainsregexp>
-                    <deletecharacters chars="Last Changed Rev: "/>
-                    <striplinebreaks/>
-                </filterchain>
-            </loadfile>
-            <delete file="${svninfo.log}"/>
-        </sequential>
-    </macrodef>
-
     <macrodef name="macro_generate_executables">
         <sequential>
             <!-- create the exe launcher of the package for Windows -->
             <antcall target="-launch4j">
-                <param name="type" value="package"/>
+                <param name="type" value="package" />
             </antcall>
 
             <!-- generate the installers -->
-            <macro_izpack_compile os="${os}" target.os="${os.windows}"/>
-            <macro_izpack_compile os="${os}" target.os="${os.linux}"/>
+            <macro_izpack_compile os="${os}" target.os="${os.windows}" />
+            <macro_izpack_compile os="${os}" target.os="${os.linux}" />
 
             <!-- create the exe launcher of the installer for Windows -->
             <antcall target="-launch4j">
-                <param name="type" value="installer"/>
+                <param name="type" value="installer" />
             </antcall>
         </sequential>
     </macrodef>
 
     <target name="-launch4j" if="is.windows">
-        <launch4j configFile="${dist.dir}/l4j-${type}.xml"/>
+        <launch4j configFile="${dist.dir}/l4j-${type}.xml" />
     </target>
 
     <macrodef name="macro_izpack_compile">
-        <attribute name="os"/>
-        <attribute name="target.os"/>
+        <attribute name="os" />
+        <attribute name="target.os" />
         <sequential>
-            <chmod file="${izpack.dir}/bin/${izpack.compile.@{os}}" perm="+x" osfamily="unix"/>
+            <chmod file="${izpack.dir}/bin/${izpack.compile.@{os}}" perm="+x" osfamily="unix" />
             <exec executable="${izpack.dir}/bin/${izpack.compile.@{os}}">
-                <arg line="${dist.dir}/install-@{target.os}.xml -b . -o ${dist.dir}/@{target.os}/${jar.installer-prefix}-@{target.os}.jar -k standard"/>
+                <arg line="${dist.dir}/install-@{target.os}.xml -b . -o ${dist.dir}/@{target.os}/${jar.installer-prefix}-@{target.os}.jar -k standard" />
             </exec>
         </sequential>
     </macrodef>
 
     <macrodef name="macro_jar">
-        <attribute name="os"/>
+        <attribute name="os" />
         <sequential>
-            <mkdir dir="${build.dir}/@{os}/lib"/>
+            <mkdir dir="${build.dir}/@{os}/lib" />
             <manifestclasspath property="@{os}.jar.classpath" jarfile="${jar.package}">
                 <classpath>
-                    <fileset dir="lib/common" includes="*.jar"/>
-                    <fileset dir="lib/@{os}" includes="*.jar"/>
+                    <fileset dir="lib/common" includes="*.jar" />
+                    <fileset dir="lib/@{os}" includes="*.jar" />
                 </classpath>
             </manifestclasspath>
             <manifest file="${build.dir}/@{os}/MANIFEST.MF">
-                <attribute name="Built-By" value="${user.name}"/>
-                <attribute name="Main-Class" value="${class.start}"/>
-                <attribute name="Class-Path" value="${@{os}.jar.classpath}"/>
+                <attribute name="Built-By" value="${user.name}" />
+                <attribute name="Main-Class" value="${class.start}" />
+                <attribute name="Class-Path" value="${@{os}.jar.classpath}" />
             </manifest>
             <jar basedir="${classes.dir}" destfile="${build.dir}/@{os}/lib/${jar.package}"
                  manifest="${build.dir}/@{os}/MANIFEST.MF">
                  <fileset dir="${src.res.dir}">
-                    <include name="**/*.*"/>
+                    <include name="**/*.*" />
                 </fileset>
             </jar>
         </sequential>
     </macrodef>
 
     <macrodef name="macro_compile">
-        <attribute name="os"/>
+        <attribute name="os" />
         <sequential>
-            <mkdir dir="${classes.dir}"/>
-            <javac failonerror="true" srcdir="${src.java.dir}" destdir="${classes.dir}" target="1.6" source="1.6" includeantruntime="false" debug="on">
-                <classpath refid="@{os}.classpath"/>
+            <mkdir dir="${classes.dir}" />
+            <javac 
+                failonerror="true"
+                srcdir="${src.java.dir}" 
+            	destdir="${classes.dir}"
+                source="${javac.source}"
+                target="${javac.target}"
+                includeantruntime="false"
+                debug="${debug}"
+                deprecation="${deprecation}">
+                <classpath refid="@{os}.classpath" />
+            	<!--
+            	<compilerarg value="-Xlint" />
+            	-->
             </javac>
         </sequential>
     </macrodef>
 
     <macrodef name="macro_standalone">
-        <attribute name="os"/>
+        <attribute name="os" />
         <sequential>
             <zip destfile="${dist.dir}/@{os}/${name.package}${version.major}.${version.minor}.${version.patch}${version.extra}${version.extra1}-@{os}.zip">
-                <zipfileset file="build/@{os}/lib/${jar.package}" prefix="${name.package}"/>
-                <zipfileset file="run.${ext.@{os}}" prefix="${name.package}" filemode="755"/>
-                <zipfileset file="license.txt" prefix="${name.package}"/>
-                <zipfileset file="release_notes.txt" prefix="${name.package}"/>
-                <zipfileset file="log4j.properties" prefix="${name.package}"/>
-                <zipfileset file="cars_def.dtd" prefix="${name.package}"/>
-                <zipfileset file="ecu_defs.dtd" prefix="${name.package}"/>
-                <zipfileset file="logger.dtd" prefix="${name.package}"/>
-                <zipfileset file="profile.dtd" prefix="${name.package}"/>
-                <zipfileset dir="plugins" prefix="${name.package}/plugins"/>
-                <zipfileset dir="lib/common" prefix="${name.package}/lib/common"/>
-                <zipfileset dir="lib/@{os}" prefix="${name.package}/lib/@{os}"/>
-                <zipfileset dir="src" prefix="${name.package}/src" excludes="**/*.template"/>
+                <zipfileset file="build/@{os}/lib/${jar.package}" prefix="${name.package}" />
+                <zipfileset file="run.${ext.@{os}}" prefix="${name.package}" filemode="755" />
+                <zipfileset file="license.txt" prefix="${name.package}" />
+                <zipfileset file="release_notes.txt" prefix="${name.package}" />
+                <zipfileset file="log4j.properties" prefix="${name.package}" />
+                <zipfileset file="cars_def.dtd" prefix="${name.package}" />
+                <zipfileset file="ecu_defs.dtd" prefix="${name.package}" />
+                <zipfileset file="logger.dtd" prefix="${name.package}" />
+                <zipfileset file="profile.dtd" prefix="${name.package}" />
+                <zipfileset dir="plugins" prefix="${name.package}/plugins" />
+                <zipfileset dir="lib/common" prefix="${name.package}/lib/common" />
+                <zipfileset dir="lib/@{os}" prefix="${name.package}/lib/@{os}" />
+                <zipfileset dir="src" prefix="${name.package}/src" excludes="**/*.template" />
             </zip>
         </sequential>
     </macrodef>

--- a/src/main/java/com/romraider/Version.java.template
+++ b/src/main/java/com/romraider/Version.java.template
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2015 RomRaider.com
+ * Copyright (C) 2006-@time.year@ RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
No significant changes here, just some old cleanup.  If you can diff ignoring whitespace it will be much simpler.

- Automatically set copyright date in Version class to current year
- parameterize source and target for javac, but leave at 1.6.  Setting source to
1.8 prompts the compiler to error "source release 1.8 requires target release 1.8"
- java compile target now uses deprecation and debug values set in -init target
- removed optimization argument.  Compiler ignores it
- remove svn-related bits.  Macro was changed to use git but not renamed.  Nothing called it anyway.