### PR TITLE
Enable a warning panel when a 64-bit JRE is detected

### DIFF
--- a/jre_warning.html
+++ b/jre_warning.html
@@ -1,35 +1,24 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
-    <head>
-        <title>Java Runtime Warning</title>
-    </head>
-    <body>
-    <center>
-    <h2>Java Runtime Warning</h2>
+	<head>
+		<title>Java Runtime Warning</title>
+	</head>
+	<body>
+	<center>
+	<h1>Java Runtime Warning</h1>
+	<h2>64-bit Java detected</H2>
 
-<p>This application and its installer both require a 32-bit Java Runtime
- Environment, even if the operating system is 64-bit.</p>
+<p>This application requires a 32-bit Java Runtime Environment, even if the operating system is 64-bit.</p>
 
-<p>If this installer is run with a 64-bit version of Java, it will not complete
- successfully.</p>
+<p>If RomRaider is run with a 64-bit version of Java, some functions will not work properly.</p>
 
-<p>If RomRaider is run with a 64-bit version of Java, it will not function
- properly.</p>
+<p>Please ensure that a 32-bit version of Java with a minimum version of 1.6 is installed.</p>
 
-<p>Please ensure that a 32-bit version of Java with a minimum version of 1.6 is
- installed.</p>
-
-<p>For further information, please consult the<br>
-<a href="http://www.romraider.com/forum/viewforum.php?f=5">RomRaider
- Troubleshooting Forum</a>.</p>
-
-<p>To download a 32-bit version of Java, please visit
- <a href="http://java.sun.com/javase/downloads/index.jsp">Java SE Downloads</a>
- and choose a x86 JRE for your operating system.</p>
+<p>For further information, please consult the <a href="http://www.romraider.com/forum/viewforum.php?f=5">RomRaider Troubleshooting Forum</a></p>
 
 <p>It is recommended that you <b>cancel</b> the RomRaider installation now by
  pressing the <b>Quit</b> button below.</p>
 
-    </center>
-    </body>
+	</center>
+	</body>
 </html>

--- a/templates/install-windows.xml.template
+++ b/templates/install-windows.xml.template
@@ -8,88 +8,88 @@
         <appname>@name.package@</appname>
         <appversion>@version.major@.@version.minor@.@version.patch@ @version.extra@ @version.extra1@</appversion>
         <authors>
-            <author name="@name.maintainer@" email="@email.maintainer@"/>
+            <author name="@name.maintainer@" email="@email.maintainer@" />
         </authors>
         <url>@supporturl@</url>
     </info>
-    <native type="izpack" name="ShellLink.dll"/>
-    <guiprefs width="640" height="480" resizable="no"/>
+
+    <native type="izpack" name="ShellLink.dll" />
+    <native type="izpack" name="ShellLink_x64.dll" />
+    <guiprefs width="640" height="480" resizable="no" />
+
     <locale>
-        <langpack iso3="eng"/>
+        <langpack iso3="eng" />
     </locale>
+
     <resources>
-        <res id="LicencePanel.licence" src="license.txt"/>
-        <res id="HTMLInfoPanel.info" src="jre_warning.html"/>
-        <res id="InfoPanel.info" src="release_notes.txt"/>
-        <res id="shortcutSpec.xml" src="build/dist/shortcutSpec-windows.xml"/>
+        <res id="LicencePanel.licence" src="license.txt" />
+        <res id="HTMLInfoPanel.info" src="jre_warning.html" />
+        <res id="InfoPanel.info" src="release_notes.txt" />
+        <res id="shortcutSpec.xml" src="build/dist/shortcutSpec-windows.xml" />
     </resources>
 
     <panels>
         <panel classname="HTMLInfoPanel">
             <os arch="amd64" />
         </panel>
-        <panel classname="InfoPanel"/>
-        <panel classname="LicencePanel"/>
-        <panel classname="TargetPanel"/>
-        <panel classname="PacksPanel"/>
-        <panel classname="ShortcutPanel"/>
-        <panel classname="InstallPanel"/>
-        <panel classname="SimpleFinishPanel"/>
+        <panel classname="InfoPanel" />
+        <panel classname="LicencePanel" />
+        <panel classname="TargetPanel" />
+        <panel classname="PacksPanel" />
+        <panel classname="ShortcutPanel" />
+        <panel classname="InstallPanel" />
+        <panel classname="SimpleFinishPanel" />
     </panels>
 
     <packs>
         <pack name="Base" required="yes">
             <description>RomRaider binary files</description>
-            <file src="build/windows/lib/@name.package@.jar" targetdir="$INSTALL_PATH"/>
-            <file src="build/dist/@name.package@.exe" targetdir="$INSTALL_PATH"/>
-            <file src="license.txt" targetdir="$INSTALL_PATH"/>
-            <file src="release_notes.txt" targetdir="$INSTALL_PATH"/>
+            <file src="build/windows/lib/@name.package@.jar" targetdir="$INSTALL_PATH" />
+            <file src="build/dist/@name.package@.exe" targetdir="$INSTALL_PATH" />
+            <file src="license.txt" targetdir="$INSTALL_PATH" />
+            <file src="release_notes.txt" targetdir="$INSTALL_PATH" />
 
-            <file src="log4j.properties" targetdir="$INSTALL_PATH"/>
+            <file src="log4j.properties" targetdir="$INSTALL_PATH" />
 
-            <file src="cars_def.dtd" targetdir="$INSTALL_PATH"/>
-            <file src="ecu_defs.dtd" targetdir="$INSTALL_PATH"/>
-            <file src="logger.dtd" targetdir="$INSTALL_PATH"/>
-            <file src="profile.dtd" targetdir="$INSTALL_PATH"/>
+            <file src="cars_def.dtd" targetdir="$INSTALL_PATH" />
+            <file src="ecu_defs.dtd" targetdir="$INSTALL_PATH" />
+            <file src="logger.dtd" targetdir="$INSTALL_PATH" />
+            <file src="profile.dtd" targetdir="$INSTALL_PATH" />
 
-            <file src="post-install-tasks.bat" targetdir="$INSTALL_PATH"/>
+            <file src="post-install-tasks.bat" targetdir="$INSTALL_PATH" />
 
-            <file src="plugins/aem2.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/aem.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/aem.xwifi.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/apsx.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/fourteenpoint7.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/ecotrons.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/innovate.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/lm2_mts.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/mrf.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/phidget_ik.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/plx.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/te.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/txs_tuner.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/txs_utec.plugin" targetdir="$INSTALL_PATH/plugins"/>
-            <file src="plugins/zt2.plugin" targetdir="$INSTALL_PATH/plugins"/>
+            <file src="plugins/aem2.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/aem.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/aem.xwifi.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/fourteenpoint7.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/innovate.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/lm2_mts.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/mrf.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/phidget_ik.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/plx.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/te.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/txs_tuner.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/txs_utec.plugin" targetdir="$INSTALL_PATH/plugins" />
+            <file src="plugins/zt2.plugin" targetdir="$INSTALL_PATH/plugins" />
 
-            <fileset dir="lib/common" targetdir="$INSTALL_PATH/lib/common"/>
-            <fileset dir="lib/windows" targetdir="$INSTALL_PATH/lib/windows"/>
+            <fileset dir="lib/common" targetdir="$INSTALL_PATH/lib/common" />
+            <fileset dir="lib/windows" targetdir="$INSTALL_PATH/lib/windows" />
 
             <updatecheck>
-                <include name="plugins/**"/>
-                <exclude name="plugins/aem.plugin"/>
-                <exclude name="plugins/aem2.plugin"/>
-                <exclude name="plugins/aem.xwifi.plugin"/>
-                <exclude name="plugins/apsx.plugin"/>
-                <exclude name="plugins/ecotrons.plugin"/>
-                <exclude name="plugins/fourteenpoint7.plugin"/>
-                <exclude name="plugins/innovate.plugin"/>
-                <exclude name="plugins/lm2_mts.plugin"/>
-                <exclude name="plugins/mrf.plugin"/>
-                <exclude name="plugins/phidget_ik.plugin"/>
-                <exclude name="plugins/plx.plugin"/>
-                <exclude name="plugins/te.plugin"/>
-                <exclude name="plugins/txs_tuner.plugin"/>
-                <exclude name="plugins/txs_utec.plugin"/>
-                <exclude name="plugins/zt2.plugin"/>
+                <include name="plugins/**" />
+                <exclude name="plugins/aem.plugin" />
+                <exclude name="plugins/aem2.plugin" />
+                <exclude name="plugins/aem.xwifi.plugin" />
+                <exclude name="plugins/fourteenpoint7.plugin" />
+                <exclude name="plugins/innovate.plugin" />
+                <exclude name="plugins/lm2_mts.plugin" />
+                <exclude name="plugins/mrf.plugin" />
+                <exclude name="plugins/phidget_ik.plugin" />
+                <exclude name="plugins/plx.plugin" />
+                <exclude name="plugins/te.plugin" />
+                <exclude name="plugins/txs_tuner.plugin" />
+                <exclude name="plugins/txs_utec.plugin" />
+                <exclude name="plugins/zt2.plugin" />
             </updatecheck>
 
 	        <executable targetfile="$INSTALL_PATH/post-install-tasks.bat" stage="postinstall"
@@ -103,7 +103,7 @@
 
         <pack name="Source Files" required="no">
             <description>@name.package@ Source Files</description>
-            <file src="src" targetdir="$INSTALL_PATH"/>
+            <file src="src" targetdir="$INSTALL_PATH" />
         </pack>
     </packs>
 </installation>


### PR DESCRIPTION
Installer panel is conditional on JVM architecture being detected as "amd64"

Enable 64-bit Windows for installer
- add 64-bit ShellLink DLL to installer template
- update info panel text to reflect change
Installer panel is conditional on JVM architecture being detected as "amd64"
Application is not yet 64-bit ready

Potential issue:
Specifying 32-bit Java to run the installer JAR file will bypass the warning
but the shortcuts may still use a 64-bit version