### PR TITLE
Proposed Fix for #104, Dyno Def Warning, Thread naming, ECU Init

### DIFF
--- a/log4j.properties
+++ b/log4j.properties
@@ -2,11 +2,10 @@ log4j.rootLogger=info, stdout, file
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%-5r %-5p [%t] - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} %-5p [%t] - %m%n
 
 log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.File=${user.home}/.RomRaider/rr_system.log
 log4j.appender.file.MaxBackupIndex=1
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%-5r %-5p [%t] - %m%n
-
+log4j.appender.file.layout.ConversionPattern=%d{ABSOLUTE} %-5p [%t] - %m%n

--- a/src/main/java/com/romraider/Settings.java
+++ b/src/main/java/com/romraider/Settings.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2020 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -262,17 +262,17 @@ public class Settings implements Serializable {
     /**
      * Gear selection for selected car on Dyno tab
      */
-    private String selectedGear = "";
+    private String selectedGear = "3";
 
     /**
      * Throttle threshold value to indicate WOT on Dyno tab
      */
-    private String tpsThreshold = "";
+    private String tpsThreshold = "98";
 
     /**
      * Throttle value units % or VDC on Dyno tab, not all cars support both
      */
-    private String tpsThresholdPID = "";
+    private String tpsThresholdPID = "%";
 
     /**
      * Sets if we search for the ELM327 on startup (small delay)

--- a/src/main/java/com/romraider/io/serial/port/SerialPortRefresher.java
+++ b/src/main/java/com/romraider/io/serial/port/SerialPortRefresher.java
@@ -45,6 +45,8 @@ public final class SerialPortRefresher implements Runnable {
     }
 
     public void run() {
+        Thread.currentThread().setName("Serial Port Refresher");
+        
         refreshPortList();
         started = true;
         while (true) {

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2020 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -106,6 +106,8 @@ import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.JToggleButton;
 import javax.swing.JWindow;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import javax.swing.table.TableColumn;
 
 import org.apache.log4j.Level;
@@ -953,7 +955,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
                                     buildToggleGaugeStyleButton());
             tabbedPane.add("MAF", mafTab.getPanel());
             tabbedPane.add("Injector", injectorTab.getPanel());
-            tabbedPane.add("Dyno", dynoTab.getPanel());
+            tabbedPane.add("Dyno", dynoTab.getPanel());              
         }
         else
         {
@@ -992,6 +994,17 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
             tabbedPane.add("<html><body leftmargin=15 topmargin=15 marginwidth=15 marginheight=15>" + "Injector"+ "</body></html>", injectorTab.getPanel());
             tabbedPane.add("<html><body leftmargin=15 topmargin=15 marginwidth=15 marginheight=15>" + "Dyno" + "</body></html>", dynoTab.getPanel());
         }
+                
+        //Check for definitions only when we open the dyno tab
+        tabbedPane.addChangeListener(new ChangeListener() { 
+            public void stateChanged(ChangeEvent e) {
+                if(tabbedPane.getSelectedComponent() == dynoTab.getPanel())
+                {
+                	((DynoTabImpl)dynoTab).getDynoControlPanel().checkDynoDefs();
+                }
+            }
+        });
+        
         return tabbedPane;
     }
 
@@ -1514,6 +1527,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
     private void buildModuleSelectPanel() {
         moduleSelectPanel.removeAll();
         final CustomButtonGroup moduleGroup = new CustomButtonGroup();
+
         for (Module module : getModuleList()) {
             final JCheckBox cb = new JCheckBox(module.getName().toUpperCase());
             if (touchEnabled == true)
@@ -1527,6 +1541,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
                 cb.setSelected(true);
                 setTarget(module.getName());
             }
+            
             cb.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent actionEvent) {

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -580,7 +580,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
                 }
 
                 loadResult = String.format(
-                        "%sloaded protocol %s: %d parameters, %d switches from def version %s.",
+                        "%sloaded protocol %s: %d parameters, %d switches from def version %s. ",
                         loadResult,
                         getSettings().getLoggerProtocol(),
                         ecuParams.size(),
@@ -1612,12 +1612,16 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
         return inString.replaceAll("[A-Z]{3}", newString);
     }
 
-    private Transport getTransportById(String id) {
+
+	private Transport getTransportById(String id) {
         Transport loggerTransport = null;
-        for (Transport transport : getTransportMap().keySet()) {
+        Map<Transport, Collection<Module>> transportMap = getTransportMap();
+        
+        for (Transport transport : transportMap.keySet()) {
             if (transport.getId().equalsIgnoreCase(id))
                 loggerTransport = transport;
         }
+
         return loggerTransport;
     }
 

--- a/src/main/java/com/romraider/logger/ecu/comms/manager/AsyncDataUpdateHandler.java
+++ b/src/main/java/com/romraider/logger/ecu/comms/manager/AsyncDataUpdateHandler.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2020 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,21 +23,20 @@ package com.romraider.logger.ecu.comms.manager;
 import java.util.Vector;
 
 import org.apache.log4j.Logger;
-
 import com.romraider.logger.ecu.comms.query.Response;
 import com.romraider.logger.ecu.ui.handler.DataUpdateHandler;
 
 
 public class AsyncDataUpdateHandler extends Thread {
     private static final Logger LOGGER = Logger.getLogger(AsyncDataUpdateHandler.class);
-    
+
     Vector<Response> responsesToUpdate = new Vector<Response>();
 	DataUpdateHandler[] handlers;
 	private  boolean stop = false;
 	private volatile boolean isRunning = false;
 	
 	public AsyncDataUpdateHandler(DataUpdateHandler[] handlers) {
-		this.handlers = handlers;		
+		this.handlers = handlers;
 		setName("AsyncDataUpdater");
 	}
 	
@@ -46,12 +45,10 @@ public class AsyncDataUpdateHandler extends Thread {
     	stop = false;
     	
     	while(!stop) {	    	
-    		isRunning = true;
+    		isRunning = true;	
     		
-	    	synchronized(responsesToUpdate) {
-			   
-	    		Response r;
-	    		
+	    	synchronized(responsesToUpdate) {		   
+	    		Response r;	    		
 	    		while(!responsesToUpdate.isEmpty()) {
 	    			r = responsesToUpdate.get(0);
 	    			

--- a/src/main/java/com/romraider/logger/ecu/definition/EcuDataLoaderImpl.java
+++ b/src/main/java/com/romraider/logger/ecu/definition/EcuDataLoaderImpl.java
@@ -62,7 +62,7 @@ public final class EcuDataLoaderImpl implements EcuDataLoader {
                     new FileInputStream(ecuDefsFile));
             try {
                 EcuDefinitionHandler handler = new EcuDefinitionHandler(ecuDefsFile);
-                getSaxParser().parse(inputStream, handler);
+                getSaxParser().parse(inputStream, handler, ecuDefsFile.getAbsolutePath());
                 ecuDefinitionMap = handler.getEcuDefinitionMap();
             } finally {
                 inputStream.close();
@@ -88,12 +88,11 @@ public final class EcuDataLoaderImpl implements EcuDataLoader {
         checkNotNullOrEmpty(protocol, "protocol");
         checkNotNullOrEmpty(fileLoggingControllerSwitchId, "fileLoggingControllerSwitchId");
         try {
-            InputStream inputStream = new BufferedInputStream(
-                    new FileInputStream(new File(loggerConfigFilePath)));
+            InputStream inputStream = new BufferedInputStream(new FileInputStream(new File(loggerConfigFilePath)));
             try {
                 LoggerDefinitionHandler handler = new LoggerDefinitionHandler(
                         protocol, fileLoggingControllerSwitchId, ecuInit);
-                getSaxParser().parse(inputStream, handler);
+                getSaxParser().parse(inputStream, handler, loggerConfigFilePath);
                 ecuParameters = handler.getEcuParameters();
                 ecuSwitches = handler.getEcuSwitches();
                 fileLoggingControllerSwitch = handler.getFileLoggingControllerSwitch();

--- a/src/main/java/com/romraider/logger/ecu/definition/xml/LoggerDefinitionHandler.java
+++ b/src/main/java/com/romraider/logger/ecu/definition/xml/LoggerDefinitionHandler.java
@@ -437,6 +437,7 @@ public final class LoggerDefinitionHandler extends DefaultHandler {
     }
 
     public Map<String, Map<Transport, Collection<Module>>> getProtocols() {
+    	/*
         if (protocolMap.get(protocol).isEmpty()) {
             final Module module = new Module(
                     "ecu", new byte[]{0x10}, "Engine Control Unit",
@@ -447,7 +448,7 @@ public final class LoggerDefinitionHandler extends DefaultHandler {
             transportMap = new HashMap<Transport, Collection<Module>>();
             transportMap.put(transport, moduleList);
             protocolMap.put(protocol, transportMap);
-        }
+        }*/
         return protocolMap;
     }
 

--- a/src/main/java/com/romraider/logger/ecu/ui/paramlist/ParameterListTableModel.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/paramlist/ParameterListTableModel.java
@@ -19,7 +19,6 @@
 
 package com.romraider.logger.ecu.ui.paramlist;
 
-import com.romraider.logger.ecu.definition.EcuDataType;
 import com.romraider.logger.ecu.definition.LoggerData;
 import com.romraider.logger.ecu.ui.DataRegistrationBroker;
 import com.romraider.util.ResourceUtil;

--- a/src/main/java/com/romraider/logger/ecu/ui/paramlist/ParameterListTableModel.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/paramlist/ParameterListTableModel.java
@@ -19,6 +19,7 @@
 
 package com.romraider.logger.ecu.ui.paramlist;
 
+import com.romraider.logger.ecu.definition.EcuDataType;
 import com.romraider.logger.ecu.definition.LoggerData;
 import com.romraider.logger.ecu.ui.DataRegistrationBroker;
 import com.romraider.util.ResourceUtil;

--- a/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoControlPanel.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoControlPanel.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2019 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -168,7 +168,7 @@ public final class DynoControlPanel extends JPanel {
     private boolean wotSet;
     private String path;
     private String carInfo;
-    private String[] carTypeArr;
+    private String[] carTypeArr = {MISSING_CAR_DEF};
     private String[] carMassArr;
     private String[] dragCoeffArr;
     private String[] rollCoeffArr;
@@ -1501,7 +1501,27 @@ public final class DynoControlPanel extends JPanel {
             gearList[g - 1] = Integer.toString(g);
         }
     }
-
+    
+    public void checkDynoDefs() {
+    	if (carTypeArr[0].trim().equals(MISSING_CAR_DEF)){
+	        Object[] options = {"Yes", "No"};
+	        int answer = showOptionDialog(parent,
+	                rb.getString("CDNOTFOUND"),
+	                rb.getString("CONFIGURATION"),
+	                DEFAULT_OPTION, WARNING_MESSAGE,
+	                null, options, options[0]);
+	        if (answer == 0) {
+	            BrowserControl.displayURL(CARS_DEFS_URL);
+	        } else {
+	            final String msg = MessageFormat.format(
+	                    rb.getString("MISSINGCD"), MISSING_CAR_DEF);
+	            showMessageDialog(parent,
+	            msg,
+	            rb.getString("NOTICE"), WARNING_MESSAGE);
+	        }
+    	}
+    }
+    
     private void changeCars(int index) {
         if (!carTypeArr[0].trim().equals(MISSING_CAR_DEF)) {
             iButton.doClick();
@@ -1537,13 +1557,15 @@ public final class DynoControlPanel extends JPanel {
             File carDef = null;
             final String SEPARATOR = System.getProperty("file.separator");
             final String loggerFilePath = getSettings().getLoggerDefinitionFilePath();
-            if (loggerFilePath != null) {
+            
+            if(loggerFilePath != null) {
                 final int index = loggerFilePath.lastIndexOf(SEPARATOR);
                 if (index > 0) {
                     final String path = loggerFilePath.substring(0, index + 1);
                     carDef = new File(path + CARS_FILE);
                 }
             }
+            
             if (!carDef.exists()) {
                 final String profileFilePath = getSettings().getLoggerProfileFilePath();
                 if (profileFilePath != null) {
@@ -1663,23 +1685,9 @@ public final class DynoControlPanel extends JPanel {
             ((x == null) ? e : x).printStackTrace();
         }
         catch (Throwable t) {    // file not found
-            Object[] options = {"Yes", "No"};
-            int answer = showOptionDialog(this,
-                    rb.getString("CDNOTFOUND"),
-                    rb.getString("CONFIGURATION"),
-                    DEFAULT_OPTION, WARNING_MESSAGE,
-                    null, options, options[0]);
-            if (answer == 0) {
-                BrowserControl.displayURL(CARS_DEFS_URL);
-            } else {
-                final String msg = MessageFormat.format(
-                        rb.getString("MISSINGCD"), MISSING_CAR_DEF);
-                showMessageDialog(parent,
-                msg,
-                rb.getString("NOTICE"), WARNING_MESSAGE);
-            }
             carTypeArr = new String[]{MISSING_CAR_DEF};
-            t.printStackTrace();
+            LOGGER.warn("No car_definition.xml file found!");
+            //t.printStackTrace();
         }
     }
 

--- a/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoTabImpl.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoTabImpl.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2020 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,6 +56,10 @@ public final class DynoTabImpl extends JPanel implements DynoTab {
         add(chartPanel, CENTER);
     }
 
+    public DynoControlPanel getDynoControlPanel() {
+    	return controlPanel;
+    }
+    
     @Override
     public double calcRpm(double vs) {
         return controlPanel.calcRpm(vs);

--- a/src/main/java/com/romraider/logger/external/core/GenericDataSourceConnector.java
+++ b/src/main/java/com/romraider/logger/external/core/GenericDataSourceConnector.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2012 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,6 +36,8 @@ public final class GenericDataSourceConnector implements Stoppable {
 
     public void run() {
         LOGGER.info(dataSource.getName() + ": connecting...");
+        Thread.currentThread().setName(dataSource.getName());
+        
         while (!stop) {
             try {
                 dataSource.connect();

--- a/src/main/java/com/romraider/logger/external/core/GenericDataSourceManager.java
+++ b/src/main/java/com/romraider/logger/external/core/GenericDataSourceManager.java
@@ -95,7 +95,6 @@ public final class GenericDataSourceManager implements ExternalDataSource {
     }
 
     private void doDisconnect() {
-        if (dataSource.getPort() == null) return;
         try {
             String message = String.format("%s: disconnecting port %s",
                     dataSource.getName(), dataSource.getPort());

--- a/src/main/java/com/romraider/util/SaxParserFactory.java
+++ b/src/main/java/com/romraider/util/SaxParserFactory.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2012 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,13 +20,9 @@
 package com.romraider.util;
 
 import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 
 public final class SaxParserFactory {
 
@@ -36,22 +32,9 @@ public final class SaxParserFactory {
 
     public static SAXParser getSaxParser() throws ParserConfigurationException, SAXException {
         SAXParserFactory parserFactory = SAXParserFactory.newInstance();
-        parserFactory.setNamespaceAware(false);
+        parserFactory.setNamespaceAware(true);
         parserFactory.setValidating(true);
-        parserFactory.setXIncludeAware(false);
+        parserFactory.setXIncludeAware(true);
         return parserFactory.newSAXParser();
-    }
-
-    public static void main(String args[]) {
-        try {
-            SAXParser parser = SaxParserFactory.getSaxParser();
-            BufferedInputStream b = new BufferedInputStream(new FileInputStream(new File("/ecu_defs.xml")));
-            System.out.println(b.available());
-            parser.parse(b, new DefaultHandler());
-            System.out.println(parser.isValidating());
-
-        } catch (Exception ex) {
-            System.err.println(ex);
-        }
     }
 }

--- a/src/main/java/com/romraider/xml/DOMHelper.java
+++ b/src/main/java/com/romraider/xml/DOMHelper.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2012 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,7 +47,7 @@ public final class DOMHelper {
 
     public static String unmarshallAttribute(Node node, String name, String defaultValue) {
         Node n = node.getAttributes().getNamedItem(name);
-        return (n != null) ? (n.getNodeValue()) : (defaultValue);
+        return (n != null && !n.getNodeValue().equals("NaN")) ? (n.getNodeValue()) : (defaultValue);
     }
 
     public static Double unmarshallAttribute(Node node, String name, double defaultValue) {

--- a/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2019 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hi,
this should be a solution for #104. I changed the log format to the system time, the old system is based on the creation time of the thread itself. Other changes:

- Only show the warning for missing dyno definitions when you actually open the dyno tab
- Use default values for dyno settings (creates NaN value otherwise)
- Use default value in unmarshalling if setting contains NaN (caused by point above)
- Set some thread names for easier debugging
- Only try to do an EcuInit if the module is set
- Fix a bug when trying to log an external plugin whose port was not set. This created a thread that did not get closed afterwards

Hope you find these changes useful!

Edit: I also noticed that the build.xml file contains a bootclasspath.dir property with a hard coded path, is this intentional? I commented it out and didn't notice any difference