### PR TITLE
Fix for Dyno calculation problem when locale is not en_US #106

### DIFF
--- a/i18n/com/romraider/logger/ecu/ui/StatusIndicator.properties
+++ b/i18n/com/romraider/logger/ecu/ui/StatusIndicator.properties
@@ -1,6 +1,6 @@
 # Each of these lines has a trailing space, do not remove it
 CONNECTING = Connecting 
-READING = Reading data
-READING_EXTERNAL = Reading plugins only
+READING = Reading data 
+READING_EXTERNAL = Reading plugins only 
 LOGGING = Logging to file 
 STOPPED = Stopped 

--- a/i18n/com/romraider/logger/ecu/ui/StatusIndicator.properties
+++ b/i18n/com/romraider/logger/ecu/ui/StatusIndicator.properties
@@ -1,5 +1,6 @@
 # Each of these lines has a trailing space, do not remove it
 CONNECTING = Connecting 
-READING = Reading data 
+READING = Reading data
+READING_EXTERNAL = Reading plugins only
 LOGGING = Logging to file 
 STOPPED = Stopped 

--- a/src/main/java/com/romraider/logger/car/util/Constants.java
+++ b/src/main/java/com/romraider/logger/car/util/Constants.java
@@ -19,22 +19,12 @@
 
 package com.romraider.logger.car.util;
 
-public enum Constants {
-    IMPERIAL        ("imperial"),
-    IMPERIAL_UNIT    ("mph"),
-    METRIC            ("metric"),
-    METRIC_UNIT        ("km/h"),
-    KPH_2_MPH        ("1.609344"),
-    TQ_CONSTANT_I    ("5252.113122"),
-    TQ_CONSTANT_M    ("9549.296748");
-
-    private final String value;
-    
-    Constants (String value) {
-        this.value = value;
-    }
-    
-    public String value(){
-        return value;
-    }
+public class Constants {
+    static String IMPERIAL = "imperial";
+    static String METRIC = "metric";
+    static String METRIC_UNIT = "km/h";
+    static String IMPERIAL_UNIT = "mph";
+    static double KPH_2_MPH = 1.609344;
+    static double TQ_CONSTANT_I = 5252.113122;
+    static double TQ_CONSTANT_M = 9549.296748;
 }

--- a/src/main/java/com/romraider/logger/car/util/SpeedCalculator.java
+++ b/src/main/java/com/romraider/logger/car/util/SpeedCalculator.java
@@ -24,20 +24,18 @@ import static com.romraider.logger.car.util.Constants.KPH_2_MPH;
 import static com.romraider.logger.car.util.Constants.METRIC_UNIT;
 
 public class SpeedCalculator {
-    private static final double K2M = Double.parseDouble(KPH_2_MPH.value());
-
     public static double calculateMph(double rpm, double ratio) {
         return (rpm / ratio);
     }
 
     public static double calculateKph(double rpm, double ratio) {
-        return calculateMph(rpm, ratio) * K2M;
+        return calculateMph(rpm, ratio) * KPH_2_MPH;
     }
 
     public static double calculateRpm(double vs, double ratio, String units) {
         double rpm = 0;
-        if (units.equalsIgnoreCase(IMPERIAL_UNIT.value())) rpm = (vs * ratio);
-        if (units.equalsIgnoreCase(METRIC_UNIT.value())) rpm = (vs * ratio / K2M);
+        if (units.equalsIgnoreCase(IMPERIAL_UNIT)) rpm = (vs * ratio);
+        if (units.equalsIgnoreCase(METRIC_UNIT)) rpm = (vs * ratio / KPH_2_MPH);
         return rpm;
     }
 

--- a/src/main/java/com/romraider/logger/car/util/TorqueCalculator.java
+++ b/src/main/java/com/romraider/logger/car/util/TorqueCalculator.java
@@ -28,11 +28,11 @@ public class TorqueCalculator {
 
     public static double calculateTorque(double rpm, double hp, String units) {
         double tq = 0;
-        if (units.equalsIgnoreCase(IMPERIAL.value())) {
-            tq = hp / rpm * Double.parseDouble(TQ_CONSTANT_I.value());
+        if (units.equalsIgnoreCase(IMPERIAL)) {
+            tq = hp / rpm * TQ_CONSTANT_I;
         }
-        if (units.equalsIgnoreCase(METRIC.value())) {
-            tq = hp / rpm * Double.parseDouble(TQ_CONSTANT_M.value());
+        if (units.equalsIgnoreCase(METRIC)) {
+            tq = hp / rpm * TQ_CONSTANT_M;
         }
         return tq;
     }

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -543,7 +543,11 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
 
     private void loadLoggerConfig() {
         String loggerConfigFilePath = getSettings().getLoggerDefinitionFilePath();
-        if (isNullOrEmpty(loggerConfigFilePath)) showMissingConfigDialog();
+        if (isNullOrEmpty(loggerConfigFilePath))
+        	{
+        		showMissingConfigDialog();
+        		getSettings().setLogExternalsOnly(true);
+        	}
         else {
             try {
                 EcuDataLoader dataLoader = new EcuDataLoaderImpl();
@@ -1527,40 +1531,45 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
     private void buildModuleSelectPanel() {
         moduleSelectPanel.removeAll();
         final CustomButtonGroup moduleGroup = new CustomButtonGroup();
-
-        for (Module module : getModuleList()) {
-            final JCheckBox cb = new JCheckBox(module.getName().toUpperCase());
-            if (touchEnabled == true)
-            {
-                cb.setPreferredSize(new Dimension(75, 50));
-            }
-            cb.setToolTipText(MessageFormat.format(
-                    rb.getString("TTTEXTEXTERNALS"),
-                    module.getDescription()));
-            if (getSettings().getTargetModule().equalsIgnoreCase(module.getName())) {
-                cb.setSelected(true);
-                setTarget(module.getName());
-            }
-            
-            cb.addActionListener(new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent actionEvent) {
-                    stopLogging();
-                    final JCheckBox source = (JCheckBox) actionEvent.getSource();
-                    if (source.isSelected()) {
-                        getSettings().setLogExternalsOnly(false);
-                        setTarget(source.getText());
-                    }
-                    else {
-                        getSettings().setLogExternalsOnly(true);
-                    }
-                    startLogging();
-                }
-            });
-
-            moduleGroup.add(cb);
-            moduleSelectPanel.add(cb);
-            moduleSelectPanel.validate();
+        Collection<Module> moduleList = getModuleList();
+        if(moduleList.size() == 0) {
+        	getSettings().setLogExternalsOnly(true);
+        }
+        else {
+	        for (Module module : moduleList) {
+	            final JCheckBox cb = new JCheckBox(module.getName().toUpperCase());
+	            if (touchEnabled == true)
+	            {
+	                cb.setPreferredSize(new Dimension(75, 50));
+	            }
+	            cb.setToolTipText(MessageFormat.format(
+	                    rb.getString("TTTEXTEXTERNALS"),
+	                    module.getDescription()));
+	            if (getSettings().getTargetModule().equalsIgnoreCase(module.getName())) {
+	                cb.setSelected(true);
+	                setTarget(module.getName());
+	            }
+	            
+	            cb.addActionListener(new ActionListener() {
+	                @Override
+	                public void actionPerformed(ActionEvent actionEvent) {
+	                    stopLogging();
+	                    final JCheckBox source = (JCheckBox) actionEvent.getSource();
+	                    if (source.isSelected()) {
+	                        getSettings().setLogExternalsOnly(false);
+	                        setTarget(source.getText());
+	                    }
+	                    else {
+	                        getSettings().setLogExternalsOnly(true);
+	                    }
+	                    startLogging();
+	                }
+	            });
+	
+	            moduleGroup.add(cb);
+	            moduleSelectPanel.add(cb);
+	            moduleSelectPanel.validate();
+	        }
         }
     }
 

--- a/src/main/java/com/romraider/logger/ecu/comms/manager/QueryManagerImpl.java
+++ b/src/main/java/com/romraider/logger/ecu/comms/manager/QueryManagerImpl.java
@@ -468,7 +468,10 @@ public final class QueryManagerImpl implements QueryManager {
             @Override
             public void run() {
                 for (StatusChangeListener listener : listeners) {
-                    listener.readingData();
+                	if(settings.isLogExternalsOnly()) listener.readingDataExternal();
+                	else {
+                		listener.readingData();
+                	}
                 }
             }
         });

--- a/src/main/java/com/romraider/logger/ecu/ui/DataRegistrationBrokerImpl.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/DataRegistrationBrokerImpl.java
@@ -75,7 +75,11 @@ public final class DataRegistrationBrokerImpl implements DataRegistrationBroker 
 
     public synchronized void readingData() {
     }
-
+	
+	public void readingDataExternal() {
+		
+	}
+	
     public synchronized void loggingData() {
     }
 
@@ -89,5 +93,7 @@ public final class DataRegistrationBrokerImpl implements DataRegistrationBroker 
         // deregister param from handlers
         handlerManager.deregisterData(loggerData);
     }
+
+
 
 }

--- a/src/main/java/com/romraider/logger/ecu/ui/StatusChangeListener.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/StatusChangeListener.java
@@ -24,6 +24,8 @@ public interface StatusChangeListener {
     void connecting();
 
     void readingData();
+    
+    void readingDataExternal();
 
     void loggingData();
 

--- a/src/main/java/com/romraider/logger/ecu/ui/StatusIndicator.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/StatusIndicator.java
@@ -38,6 +38,7 @@ public final class StatusIndicator extends JPanel implements StatusChangeListene
     private final JLabel statusLabel = new JLabel();
     private static final String TEXT_CONNECTING = rb.getString("CONNECTING");
     private static final String TEXT_READING = rb.getString("READING");
+    private static final String TEXT_READING_EXTERNAL = rb.getString("READING_EXTERNAL");
     private static final String TEXT_LOGGING = rb.getString("LOGGING");
     private static final String TEXT_STOPPED = rb.getString("STOPPED");
     private static final ImageIcon ICON_CONNECTING = new ImageIcon(StatusIndicator.class.getClass().getResource("/graphics/logger_blue.png"));
@@ -59,7 +60,11 @@ public final class StatusIndicator extends JPanel implements StatusChangeListene
     public void readingData() {
         updateStatusLabel(TEXT_READING, ICON_READING);
     }
-
+    
+    public void readingDataExternal() {
+        updateStatusLabel(TEXT_READING_EXTERNAL, ICON_READING);
+    }
+    
     public void loggingData() {
         updateStatusLabel(TEXT_LOGGING, ICON_LOGGING);
     }

--- a/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoControlPanel.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoControlPanel.java
@@ -1044,8 +1044,11 @@ public final class DynoControlPanel extends JPanel {
                 while ((line = inputStream.readLine()) != null) {
                 	
                 	//Convert everything to . notation
-                	line = line.replace(',', '.');
                     String[] values = line.split(delimiter);
+                    
+                    for(int i=0; i < values.length;i++) {
+                    	values[i] = values[i].replace(',', '.');
+                    }
                                                        
                     if (Double.parseDouble(values[taCol]) > tpsMin) {
                         double logTime = 0;


### PR DESCRIPTION
Hi,
this should fix #106 . I changed it so a dyno log is always converted to . notation and used the locale-independent double parser. This also fixes another bug, because the amount of samples was different depending on locale due to how the TPS value was parsed. I also changed how the dyno definitions are found to be a little bit more compact. The code looks through the local directory as well now if it doesn't find anything near the logger definition file.

As a general design question: Dont you think it would be better to always use . notation in the entire project? The comma-dot option is really error prone. I don't think it would be a big deal if everybody had to use . notation.

I think you can also close #104  :)