### PR TITLE
Editor Subcategory support

### DIFF
--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -572,7 +572,7 @@ class LaunchLoggerWorker extends SwingWorker<Void, Void> {
 
     public void propertyChange(PropertyChangeEvent evnt)
     {
-        SwingWorker source = (SwingWorker) evnt.getSource();
+        SwingWorker<?, ?> source = (SwingWorker<?, ?>) evnt.getSource();
         if (null != source && "state".equals( evnt.getPropertyName() )
                 && (source.isDone() || source.isCancelled() ) )
         {
@@ -604,7 +604,7 @@ class SetUserLevelWorker extends SwingWorker<Void, Void> {
 
     public void propertyChange(PropertyChangeEvent evnt)
     {
-        SwingWorker source = (SwingWorker) evnt.getSource();
+        SwingWorker<?, ?> source = (SwingWorker<?, ?>) evnt.getSource();
         if (null != source && "state".equals( evnt.getPropertyName() )
                 && (source.isDone() || source.isCancelled() ) )
         {
@@ -802,7 +802,7 @@ class OpenImageWorker extends SwingWorker<Void, Void> {
 
     public void propertyChange(PropertyChangeEvent evnt)
     {
-        SwingWorker source = (SwingWorker) evnt.getSource();
+        SwingWorker<?, ?> source = (SwingWorker<?, ?>) evnt.getSource();
         if (null != source && "state".equals( evnt.getPropertyName() )
                 && (source.isDone() || source.isCancelled() ) )
         {

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -88,23 +88,32 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
         for (TableTreeNode tableTreeNode : tableNodes) {
             TableFrame tableFrame = tableTreeNode.getFrame();
             Table table = tableFrame.getTable();
-
+            String[] categories = table.getCategory().split("//");
+                      
             if (settings.isDisplayHighTables() || settings.getUserLevel() >= table.getUserLevel()) {
-                boolean categoryExists = false;
-
-                for (int j = 0; j < getChildCount(); j++) {
-                    if (getChildAt(j).toString().equals(table.getCategory())) {
-                        // add to appropriate category
-                        getChildAt(j).add(tableTreeNode);
-                        categoryExists = true;
-                        break;
-                    }
-                }
-
-                if (!categoryExists) { // if category does not already exist, create it
-                    CategoryTreeNode categoryNode = new CategoryTreeNode(table.getCategory());
-                    categoryNode.add(tableTreeNode);
-                    this.add(categoryNode);
+                
+                DefaultMutableTreeNode currentParent = this;
+                
+                for(int i=0; i < categories.length; i++) {
+                    boolean categoryExists = false;
+                    
+	                for (int j = 0; j < currentParent.getChildCount(); j++) {
+	                    if (currentParent.getChildAt(j).toString().equalsIgnoreCase(categories[i])) {	  
+	                    	categoryExists = true;	                    		                    	
+	                    	currentParent = (DefaultMutableTreeNode) currentParent.getChildAt(j);
+	                        break;
+	                    }
+	                }
+	                
+	                if(!categoryExists) {
+	                    CategoryTreeNode categoryNode = new CategoryTreeNode(categories[i]);
+	                    currentParent.add(categoryNode);
+	                    currentParent = categoryNode;
+	                }
+	                
+                	if(i == categories.length - 1){
+                		currentParent.add(tableTreeNode);
+                	}
                 }
             }
         }

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -577,6 +577,7 @@ public abstract class Table extends JPanel implements Serializable {
     }
 
     public void setCategory(String category) {
+    	category = category.trim().replace(" //", "//").replace("// ", "//");
         this.category = category;
     }
 


### PR DESCRIPTION
Hi,
this implements #108. This was actually very easy to implement in just a couple of lines of code:

![subcat](https://user-images.githubusercontent.com/9764527/131982890-8ee47abc-eaa2-45b7-87fa-18fde503a835.PNG)

Syntax is category="cat1//sub1//sub2//...", there is no limit on depth. I initially wanted to use a single "/", but that character can be used in normal naming conventions sometimes.

Here is an example def for a Subaru ROM: 
[ecu_defs_subcat.zip](https://github.com/RomRaider/RomRaider/files/7104831/ecu_defs_subcat.zip)

