### PR TITLE
Fix for comparing images

### DIFF
--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -120,8 +120,8 @@ public class DataCell {
         return dataValue;
     }
     
-    private double getValueFromMemory() {    	   	
-    	if (table.getSubtractLayout()) {
+    private double getValueFromMemory() {  	
+    	if (table.getDataLayout() == Table.DataLayout.BOSCH_SUBTRACT) {
     		
         	//Bosch Motronic subtract method
         	 double dataValue = Math.pow(2, 8 * table.getStorageType());
@@ -144,11 +144,12 @@ public class DataCell {
         Endian endian = table.getEndian();
         int ramOffset = table.getRamOffset();
         int storageAddress = table.getStorageAddress();
+        boolean isBoschSubtract = table.getDataLayout() == Table.DataLayout.BOSCH_SUBTRACT;
         
     	double crossedValue = 0;
        
         //Do reverse cross referencing in for Bosch Subtract Axis array
-    	if(table.getSubtractLayout()) {  		
+    	if(isBoschSubtract) {  		
     	    for (int i = table.data.length - 1; i >=index ; i--) {
 	        	if(i == index)
 	        		crossedValue -= table.data[i].getDataCell().getBinValue();
@@ -184,7 +185,7 @@ public class DataCell {
                         //LOGGER.debug("The static data table value will not be saved.");
                         return;
                     }  else {  
-                    	finalValue = (int) (table.getSubtractLayout() ? crossedValue : getBinValue());     
+                    	finalValue = (int) (isBoschSubtract ? crossedValue : getBinValue());     
                     }
                     
                 	if(mask != 0) {
@@ -236,7 +237,7 @@ public class DataCell {
         }
         
         //On the Bosch substract model, we need to update all previous cells, because they depend on our value
-        if(table.getSubtractLayout() && index > 0) table.data[index-1].getDataCell().saveBinValueInFile();
+        if(isBoschSubtract && index > 0) table.data[index-1].getDataCell().saveBinValueInFile();
         
         DataCell.checkForDataUpdates(this);          
     }

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -91,6 +91,10 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         this.setPreferredSize(getSettings().getCellSize());
     }
     
+    public boolean equals (DataCellView v) {
+    	return v.dataCell.equals(dataCell);
+    }
+    
     public DataCell getDataCell() {
     	return dataCell;
     }

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -745,7 +745,7 @@ public abstract class Table extends JPanel implements Serializable {
             }
 
 			if (this.bitMask != otherTable.bitMask) {
-				return true;
+				return false;
 			}
 			
             if(this.data.equals(otherTable.data))

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -1096,14 +1096,12 @@ public abstract class Table extends JPanel implements Serializable {
         this.beforeRam = beforeRam;
     }
     
-    public void setDataLayout(String s) {  	
-    	switch(s.trim().toLowerCase()) {
-	    	case "bosch_subtract":
-	    		setDataLayout(DataLayout.BOSCH_SUBTRACT);
-	    		break;
-	    	case "default":
-	    		setDataLayout(DataLayout.DEFAULT);
-	    		break;
+    public void setDataLayout(String s) {
+    	if(s.trim().equalsIgnoreCase("bosch_subtract")) {
+    		setDataLayout(DataLayout.BOSCH_SUBTRACT);
+    	}
+    	else {
+    		setDataLayout(DataLayout.DEFAULT);
     	}
     }
     

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -129,9 +129,14 @@ public abstract class Table extends JPanel implements Serializable {
     protected int liveDataIndex = 0;
     protected int previousLiveDataIndex = 0;
     
-    protected boolean substractLayout = false; //Bosch Style Subtract Method
+    protected DataLayout dataLayout = DataLayout.DEFAULT;
     private Table compareTable = null;
-
+    
+    public enum DataLayout {
+    	DEFAULT,
+    	BOSCH_SUBTRACT
+    }
+    
     protected Table() {
         scales.clear();
 
@@ -1091,12 +1096,23 @@ public abstract class Table extends JPanel implements Serializable {
         this.beforeRam = beforeRam;
     }
     
-    public void setSubtractLayout(boolean value) {
-        this.substractLayout = value;
+    public void setDataLayout(String s) {  	
+    	switch(s.trim().toLowerCase()) {
+	    	case "bosch_subtract":
+	    		setDataLayout(DataLayout.BOSCH_SUBTRACT);
+	    		break;
+	    	case "default":
+	    		setDataLayout(DataLayout.DEFAULT);
+	    		break;
+    	}
     }
     
-    public boolean getSubtractLayout() {
-        return this.substractLayout;
+    public void setDataLayout(DataLayout m) {
+        this.dataLayout = m;
+    }
+    
+    public DataLayout getDataLayout() {
+        return this.dataLayout;
     }
     
 	public void setStringMask(String stringMask) {	

--- a/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
@@ -382,10 +382,8 @@ public final class DOMRomUnmarshaller {
             table.setBeforeRam(true);
         }        
         
-        if (unmarshallAttribute(tableNode, "substractLayout", false)) {
-            table.setSubtractLayout(true);
-        }
-
+        
+        table.setDataLayout(unmarshallAttribute(tableNode, "dataLayout", ""));        
         table.setCategory(unmarshallAttribute(tableNode, "category",
                 table.getCategory()));
         if (table.getStorageType() < 1) {


### PR DESCRIPTION
Hi,
this is a small fix for comparing images. After the latest table refactoring a bug occurred where the tables weren't compared correctly.

Edit: I made another change regarding the bosch axis. Instead of subtractLayout=true I changed it into dataLayout='bosch_subtract'. That way it's more future proof if other special axis layouts have to be implemented.