### PR TITLE
GitHub Action to automatically bump copyright date

### DIFF
--- a/.github/workflows/CopyrightUpdate.yml
+++ b/.github/workflows/CopyrightUpdate.yml
@@ -1,0 +1,29 @@
+name: Copyright Update
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  Copyright-Update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y')"
+      - uses: actions/checkout@v2
+      - name: Find and Replace
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          find: "Copyright .{3} [0-9]{4}-[0-9]{4}"
+          replace: "Copyright (C) 2006-${{ steps.date.outputs.date }}"
+          include: "src/"    
+      - name: Commit Changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: 'Update copyright date'
+          commit_options: '--no-verify'
+          repository: .
+          commit_user_name: Copyright Action


### PR DESCRIPTION
Hi,
I experimented with GitHub actions today and created an action that will automatically bump the copyright date after a push or pull request. Is this an essential tool that RomRaider cannot live without? Probably not...

Pros:
 - No manual labor
 - Coolness factor
Cons:
 - Will change the commit message shown in Github for every file that is not up-to-date
 - Will do the above every new year
 - Will create an additional commit in the GitHub repo after your push. So you should probably pull the upstream more often before you start to work on something else

This was more a fun excercise, so I wont be mad if you dont want to merge this :)

