### PR TITLE
Complete Table Rework Part 2

### DIFF
--- a/i18n/com/romraider/maps/Table.properties
+++ b/i18n/com/romraider/maps/Table.properties
@@ -1,7 +1,0 @@
-USERLVLTOLOW = This table can only be modified by users with a userlevel of \n{0} or greater. Click View->User Level to change your userlevel.
-TBLNOTMODIFY = Table cannot be modified
-REALBYTEINVALID = The real value and byte value conversion expressions for table {0} are invalid.
-REALVALUE = To real value: {0}
-BYTEVALUE = To byte: {0}
-DISPLAYMSG = Always display this message
-WARNING = Warning

--- a/i18n/com/romraider/maps/Table3D.properties
+++ b/i18n/com/romraider/maps/Table3D.properties
@@ -1,2 +1,0 @@
-USERLVLTOLOW = This table can only be modified by users with a userlevel of \n{0} or greater. Click View->User Level to change your userlevel.
-TBLNOTMODIFY = Table cannot be modified

--- a/i18n/com/romraider/maps/Table3DView.properties
+++ b/i18n/com/romraider/maps/Table3DView.properties
@@ -1,0 +1,2 @@
+USERLVLTOLOW = This table can only be modified by users with a userlevel of \n{0} or greater. Click View->User Level to change your userlevel.
+TBLNOTMODIFY = Table cannot be modified

--- a/i18n/com/romraider/maps/TableView.properties
+++ b/i18n/com/romraider/maps/TableView.properties
@@ -1,0 +1,7 @@
+USERLVLTOLOW = This table can only be modified by users with a userlevel of \n{0} or greater. Click View->User Level to change your userlevel.
+TBLNOTMODIFY = Table cannot be modified
+REALBYTEINVALID = The real value and byte value conversion expressions for table {0} are invalid.
+REALVALUE = To real value: {0}
+BYTEVALUE = To byte: {0}
+DISPLAYMSG = Always display this message
+WARNING = Warning

--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -429,12 +429,10 @@ public class ECUEditor extends AbstractFrame {
 
         rom.clearData();
         rom.removeFromParent();
-        rom = null;
 
         if (imageRoot.getChildCount() > 0) {
             editor.setLastSelectedRom((Rom) imageRoot.getChildAt(0));
         } else {
-            // no other images open
             editor.setLastSelectedRom(null);
         }
 

--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -74,6 +74,17 @@ import org.xml.sax.SAXParseException;
 import com.romraider.Settings;
 import com.romraider.logger.ecu.EcuLogger;
 import com.romraider.maps.Rom;
+import com.romraider.maps.Table1D;
+import com.romraider.maps.Table1DView;
+import com.romraider.maps.Table2D;
+import com.romraider.maps.Table2DView;
+import com.romraider.maps.Table3D;
+import com.romraider.maps.Table3DView;
+import com.romraider.maps.TableBitwiseSwitch;
+import com.romraider.maps.TableBitwiseSwitchView;
+import com.romraider.maps.TableSwitch;
+import com.romraider.maps.TableSwitchView;
+import com.romraider.maps.TableView;
 import com.romraider.net.BrowserControl;
 import com.romraider.net.URL;
 import com.romraider.swing.AbstractFrame;
@@ -86,6 +97,7 @@ import com.romraider.swing.RomTree;
 import com.romraider.swing.RomTreeRootNode;
 import com.romraider.swing.TableFrame;
 import com.romraider.swing.TableToolBar;
+import com.romraider.swing.TableTreeNode;
 import com.romraider.util.ResourceUtil;
 import com.romraider.util.SettingsManager;
 import com.romraider.xml.DOMRomUnmarshaller;
@@ -333,8 +345,10 @@ public class ECUEditor extends AbstractFrame {
         }
     }
 
-    public void displayTable(TableFrame frame) {
-        try {
+    public void displayTable(TableTreeNode node) {
+    	TableFrame frame = node.getFrame();
+    	
+        try {	
             // check if frame has been added.
             for(JInternalFrame curFrame : getRightPanel().getAllFrames()) {
                 if(curFrame.equals(frame)) {
@@ -369,12 +383,32 @@ public class ECUEditor extends AbstractFrame {
                 }
             }
 
+            if(frame == null) {
+            	TableView v;
+            	
+	        	if(node.getTable() instanceof TableSwitch)
+	        		v = new TableSwitchView((TableSwitch)node.getTable());
+	        	else if(node.getTable() instanceof TableBitwiseSwitch)
+	        		v = new TableBitwiseSwitchView((TableBitwiseSwitch)node.getTable());
+	        	else if(node.getTable() instanceof Table1D)
+	        		v = new Table1DView((Table1D)node.getTable());
+	        	else if(node.getTable() instanceof Table2D)
+	        		v = new Table2DView((Table2D)node.getTable());
+	        	else if(node.getTable() instanceof Table3D)
+	        		v = new Table3DView((Table3D)node.getTable());
+	        	else
+	        		return;
+	        	 Rom rom = RomTree.getRomNode(node);
+	        	 
+	        	 frame = new TableFrame(node.getTable().getName() + " | " + rom.getFileName(), v);
+            }
             // frame not added.  Draw table and add the frame.
             frame.getTable().getTableView().drawTable();
             rightPanel.add(frame);
         } catch (IllegalArgumentException ex) {
             ;// Do nothing.
         }
+        
         frame.pack();
         rightPanel.repaint();
     }

--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -371,7 +371,7 @@ public class ECUEditor extends AbstractFrame {
             }
 
             // frame not added.  Draw table and add the frame.
-            frame.getTable().drawTable();
+            frame.getTable().getTableView().drawTable();
             rightPanel.add(frame);
         } catch (IllegalArgumentException ex) {
             ;// Do nothing.

--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -398,10 +398,11 @@ public class ECUEditor extends AbstractFrame {
 	        		v = new Table3DView((Table3D)node.getTable());
 	        	else
 	        		return;
-	        	 Rom rom = RomTree.getRomNode(node);
-	        	 
+	        	
+	        	 Rom rom = RomTree.getRomNode(node);	        	 
 	        	 frame = new TableFrame(node.getTable().getName() + " | " + rom.getFileName(), v);
             }
+            
             // frame not added.  Draw table and add the frame.
             frame.getTable().getTableView().drawTable();
             rightPanel.add(frame);

--- a/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
@@ -34,6 +34,7 @@ import com.romraider.logger.ecu.ui.handler.DataUpdateHandler;
 import com.romraider.maps.Table;
 import com.romraider.maps.Table2D;
 import com.romraider.maps.Table3D;
+import com.romraider.maps.TableView;
 
 public final class TableUpdateHandler implements DataUpdateHandler {
     private static final TableUpdateHandler INSTANCE = new TableUpdateHandler();
@@ -56,7 +57,8 @@ public final class TableUpdateHandler implements DataUpdateHandler {
 		            if (tables != null && !tables.isEmpty()) {
 		                String formattedValue = loggerData.getSelectedConvertor().format(response.getDataValue(loggerData));
 		                for(ListIterator<Table> item = tables.listIterator(); item.hasNext();) {
-		                    item.next().highlightLiveData(formattedValue);
+		                	TableView v = item.next().getTableView();
+		                	if(v!= null) v.highlightLiveData(formattedValue);
 		                }
 		            }
 		        }

--- a/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
@@ -92,6 +92,8 @@ public final class TableUpdateHandler implements DataUpdateHandler {
     }
 
     public void deregisterTable(Table table) {
+    	if(table == null) return;
+    	
         String logParam = table.getLogParam();
         if (tableMap.containsKey(logParam)) {
             List<Table> tables = tableMap.get(logParam);

--- a/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
@@ -72,6 +72,8 @@ public final class TableUpdateHandler implements DataUpdateHandler {
 
     @Override
     public void cleanUp() {
+    	for(List<Table> t: tableMap.values())t.clear();
+    	tableMap.clear();
     }
 
     @Override

--- a/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/handler/table/TableUpdateHandler.java
@@ -63,7 +63,7 @@ public final class TableUpdateHandler implements DataUpdateHandler {
 		            }
 		        }
 	    	}
-	    	}
+	    }
     }
 
     @Override

--- a/src/main/java/com/romraider/logger/ecu/ui/tab/injector/InjectorControlPanel.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/tab/injector/InjectorControlPanel.java
@@ -433,11 +433,11 @@ public final class InjectorControlPanel extends JPanel {
                             rb.getString("INJFLOWSCALING")) == OK_OPTION) {
                         Table2D table = getInjectorFlowTable(ecuEditor);
                         if (table != null) {
-                            DataCellView[] cells = table.getData();
+                            DataCell[] cells = table.getData();
                             if (cells.length == 1) {
                                 if (isNumber(flowScaling)) {
                                     String value = flowScaling.getText().trim();
-                                    cells[0].getDataCell().setRealValue(value);
+                                    cells[0].setRealValue(value);
                                 } else {
                                     showMessageDialog(parent,
                                             rb.getString("INVALIDSCALING"),
@@ -472,12 +472,12 @@ public final class InjectorControlPanel extends JPanel {
                     if (showUpdateTableConfirmation(rb.getString("INJLAT")) == OK_OPTION) {
                         Table2D table = getInjectorLatencyTable(ecuEditor);
                         if (table != null) {
-                            DataCellView[] cells = table.getData();
+                            DataCell[] cells = table.getData();
                             if (isNumber(latencyOffset)) {
-                                for (DataCellView cell : cells) {
-                                    double newLatency = cell.getDataCell().getRealValue()
+                                for (DataCell cell : cells) {
+                                    double newLatency = cell.getRealValue()
                                             + parseDouble(latencyOffset);
-                                    cell.getDataCell().setRealValue("" + newLatency);
+                                    cell.setRealValue("" + newLatency);
                                 }
                             } else {
                                 showMessageDialog(parent,

--- a/src/main/java/com/romraider/logger/ecu/ui/tab/maf/MafControlPanel.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/tab/maf/MafControlPanel.java
@@ -60,6 +60,7 @@ import com.romraider.logger.ecu.definition.ExternalData;
 import com.romraider.logger.ecu.definition.LoggerData;
 import com.romraider.logger.ecu.ui.DataRegistrationBroker;
 import com.romraider.logger.ecu.ui.tab.LoggerChartPanel;
+import com.romraider.maps.DataCell;
 import com.romraider.maps.DataCellView;
 import com.romraider.maps.Rom;
 import com.romraider.maps.Table;
@@ -431,19 +432,19 @@ public final class MafControlPanel extends JPanel {
                         Table2D table = getMafTable(ecuEditor);
                         if (table != null) {
                             if (isValidRange(mafvMin, mafvMax)) {
-                                DataCellView[] axisCells = table.getAxis().getData();
+                                DataCell[] axisCells = table.getAxis().getData();
                                 double[] x = new double[axisCells.length];
                                 for (int i = 0; i < axisCells.length; i++) {
-                                    DataCellView cell = axisCells[i];
-                                    x[i] = cell.getDataCell().getRealValue();
+                                    DataCell cell = axisCells[i];
+                                    x[i] = cell.getRealValue();
                                 }
                                 double[] percentChange = chartPanel.calculate(x);
-                                DataCellView[] dataCells = table.getData();
+                                DataCell[] dataCells = table.getData();
                                 for (int i = 0; i < dataCells.length; i++) {
-                                    if (inRange(axisCells[i].getDataCell().getRealValue(), mafvMin, mafvMax)) {
-                                        DataCellView cell = dataCells[i];
-                                        double value = cell.getDataCell().getRealValue();
-                                        cell.getDataCell().setRealValue("" + (value * (1.0 + percentChange[i] / 100.0)));
+                                    if (inRange(axisCells[i].getRealValue(), mafvMin, mafvMax)) {
+                                        DataCell cell = dataCells[i];
+                                        double value = cell.getRealValue();
+                                        cell.setRealValue("" + (value * (1.0 + percentChange[i] / 100.0)));
                                     }
                                 }
                             } else {

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 
 import com.romraider.Settings;
 import com.romraider.Settings.Endian;
+import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.util.ByteUtil;
 import com.romraider.util.JEPUtil;
 import com.romraider.util.NumberUtil;
@@ -292,7 +293,10 @@ public class DataCell {
         if(!table.isStaticDataTable() && this.isSelected != selected) {
             this.isSelected = selected;
             
-            if(view!=null) view.drawCell();
+            if(view!=null) {
+            	ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
+            	view.drawCell();
+            }
         }
     }
     

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -44,6 +44,10 @@ public class DataCell {
     private DataCellView view = null;
     private final Table table;
     
+    //This sounds like a View property, but the manipulations
+    //functions depend on this, so its better to put it here
+    private boolean isSelected = false;
+    
     private double binValue = 0.0;
     private double originalValue = 0.0;
     private double compareToValue = 0.0;
@@ -283,7 +287,18 @@ public class DataCell {
     {
         return SettingsManager.getSettings();
     }
-     
+    
+    public void setSelected(boolean selected) {
+        if(!table.isStaticDataTable() && this.isSelected != selected) {
+            this.isSelected = selected;
+            
+            if(view!=null) view.drawCell();
+        }
+    }
+    
+    public boolean isSelected() {
+    	return isSelected;
+    }
     public void updateBinValueFromMemory() {
     	this.binValue = getValueFromMemory();
     	updateView();

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -77,6 +77,9 @@ public class DataCell {
         DataCell.registerDataCell(this);
     }
     
+    public byte[] getBinary() {
+    	return input;
+    }
     
     private double getValueFromMemory(int index) {
         double dataValue = 0.0;
@@ -138,7 +141,9 @@ public class DataCell {
     	}
     }
     
-    public void saveBinValueInFile() {
+    public void saveBinValueInFile() {    	
+    	if (table.getName().contains("Checksum Fix")) return;
+    	
         byte[] binData = input;
     	int userLevel = table.getUserLevel();
     	int storageType = table.getStorageType();
@@ -377,7 +382,7 @@ public class DataCell {
     }
 
     public void setBinValue(double newBinValue) throws UserLevelException {
-        if(binValue == newBinValue || table.locked) {
+        if(binValue == newBinValue || table.locked || table.getName().contains("Checksum Fix")) {
             return;
         }
         

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -294,7 +294,7 @@ public class DataCell {
     
     private void updateView() {
     	if(view != null)
-    		view.repaint();
+    		view.drawCell();
     }
     
     public Table getTable() {

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -50,16 +50,18 @@ public class DataCell {
     private String liveValue = Settings.BLANK;
     private String staticText = null;
     private boolean isSelected = false;
+    private byte[] input;
     
     //Index within table
     private int index;
 
-    public DataCell(Table table) {
+    public DataCell(Table table, byte[] input) {
         this.table = table;
+        this.input = input;
     }
 
     public DataCell(Table table, String staticText) {
-        this(table);
+        this(table, new byte[] {});
         final StringTokenizer st = new StringTokenizer(staticText, DataCellView.ST_DELIMITER);
         if (st.hasMoreTokens()) {
             this.staticText = st.nextToken();
@@ -67,8 +69,8 @@ public class DataCell {
         table.setStaticDataTable(true);
     }
 
-    public DataCell(Table table, int index) {
-        this(table);
+    public DataCell(Table table, int index, byte[] input) {
+        this(table, input);
         this.index = index;
         
         updateBinValueFromMemory();   
@@ -79,8 +81,7 @@ public class DataCell {
     
     private double getValueFromMemory(int index) {
         double dataValue = 0.0;
-        
-        byte[] input = table.getInputFile();
+       
         int storageType = table.getStorageType();
         Endian endian = table.getEndian();
         int ramOffset = table.getRamOffset();
@@ -139,7 +140,7 @@ public class DataCell {
     }
     
     public void saveBinValueInFile() {
-        byte[] binData = table.getInputFile();
+        byte[] binData = input;
     	int userLevel = table.getUserLevel();
     	int storageType = table.getStorageType();
         Endian endian = table.getEndian();

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -49,6 +49,7 @@ public class DataCell {
     private double compareToValue = 0.0;
     private String liveValue = Settings.BLANK;
     private String staticText = null;
+    private boolean isSelected = false;
     
     //Index within table
     private int index;
@@ -152,7 +153,7 @@ public class DataCell {
     	if(isBoschSubtract) {  		
     	    for (int i = table.data.length - 1; i >=index ; i--) {
 	        	if(i == index)
-	        		crossedValue -= table.data[i].getDataCell().getBinValue();
+	        		crossedValue -= table.data[i].getBinValue();
 	        	else if(i == table.data.length - 1) 
 	        		crossedValue = Math.pow(2, 8 * storageType) - getValueFromMemory(i);
 	        	else {
@@ -171,7 +172,7 @@ public class DataCell {
                 	
                     // convert byte values
                     if(table.isStaticDataTable() && storageType > 0) {
-                    	LOGGER.warn("Static data table: " + table.getName() + ", storageType: "+storageType);
+                    	LOGGER.warn("Static data table: " + table.toString() + ", storageType: "+storageType);
                         
                     	try {
                         	finalValue = Integer.parseInt(getStaticText());                            
@@ -237,7 +238,7 @@ public class DataCell {
         }
         
         //On the Bosch substract model, we need to update all previous cells, because they depend on our value
-        if(isBoschSubtract && index > 0) table.data[index-1].getDataCell().saveBinValueInFile();
+        if(isBoschSubtract && index > 0) table.data[index-1].saveBinValueInFile();
         
         DataCell.checkForDataUpdates(this);          
     }
@@ -475,7 +476,17 @@ public class DataCell {
     public void multiplyRaw(double factor) {
         setBinValue(binValue * factor);
     }
-
+    
+    public void setSelected(boolean selected) {
+        if(!table.isStaticDataTable() && this.isSelected != selected) {
+            this.isSelected = selected;
+        }
+    }
+    
+    public boolean isSelected() {
+    	return isSelected;
+    }
+    
     @Override
     public boolean equals(Object other) {
         if(other == null) {

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -294,7 +294,7 @@ public class DataCell {
     
     private void updateView() {
     	if(view != null)
-    		view.drawCell();
+    		view.repaint();
     }
     
     public Table getTable() {

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -58,7 +58,6 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
     private int x = 0;
     private int y = 0;
     
-    private boolean selected = false;
     private boolean highlighted = false;
     private boolean traced = false;
     private boolean tracedStale = false;
@@ -128,7 +127,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
 
         if(highlighted) {
             backgroundColor = settings.getHighlightColor();
-        } else if(selected) {
+        } else if(dataCell.isSelected()) {
             backgroundColor = settings.getSelectColor();
         } else if(null == table.getCompareTable()) {
             backgroundColor = getBinColor();
@@ -238,7 +237,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
             }
         } else if (highlighted) {
             textColor = Settings.highlightTextColor;
-        } else if (selected) {
+        } else if (dataCell.isSelected()) {
             textColor = Settings.selectTextColor;
         } else {
             textColor = Settings.scaleTextColor;
@@ -335,8 +334,8 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         if(isHighlighted()) {
             setHighlighted(false);
         }
-        if(isSelected()) {
-            setSelected(false);
+        if(dataCell.isSelected()) {
+        	dataCell.setSelected(false);
         }
     }
 
@@ -346,16 +345,6 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         return getCellText();
     }
 
-    public boolean isSelected() {
-        return selected;
-    }
-
-    public void setSelected(boolean selected) {
-        if(!table.isStaticDataTable() && this.selected != selected) {
-            this.selected = selected;
-            drawCell();
-        }
-    }
 
     public void setHighlighted(boolean highlighted) {
         if(!table.isStaticDataTable() && this.highlighted != highlighted) {

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -81,6 +81,8 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         this.addMouseListener(this);
         
         cell.setDataView(this);
+        this.y = cell.getIndexInTable();
+        this.setPreferredSize(getSettings().getCellSize());
     }
     
     public DataCellView(DataCell cell, TableView view, int x, int y) {
@@ -88,12 +90,12 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
     	
         this.x = x;
         this.y = y;
-        this.setPreferredSize(getSettings().getCellSize());
     }
     
     public void setSelected(boolean selected) {
         if(!tableView.getTable().isStaticDataTable() && this.isSelected != selected) {
             this.isSelected = selected;
+            drawCell();
         }
     }
     

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -90,6 +90,10 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         this.setPreferredSize(getSettings().getCellSize());
     }
     
+    public boolean isSelected() {
+    	return dataCell.isSelected();
+    }
+    
     public boolean equals (DataCellView v) {
     	return v.dataCell.equals(dataCell);
     }

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -116,7 +116,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
     }
     
     public void drawCell() {
-        if(tableView == null) {
+        if(tableView == null || tableView.isHidden()) {
             // Table will be null in the static case.
             return;
         }
@@ -290,9 +290,12 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
     }
 
     public String getCellText() {
-        if(tableView.getTable().isStaticDataTable()) {
+        if(tableView.getTable().getCurrentScale() == null) return "";
+        
+    	if(tableView.getTable().isStaticDataTable()) {
             return getStaticText();
         }
+        
 
         FORMATTER.applyPattern(tableView.getTable().getCurrentScale().getFormat());
         String displayString = "";

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -278,14 +278,11 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         return border;
     }
 
-    public String getCellText() {
-        if(tableView.getTable().getCurrentScale() == null) return "";
-        
+    public String getCellText() {        
     	if(tableView.getTable().isStaticDataTable()) {
             return getStaticText();
         }
-        
-
+               
         FORMATTER.applyPattern(tableView.getTable().getCurrentScale().getFormat());
         String displayString = "";
 

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -58,6 +58,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
     private int x = 0;
     private int y = 0;
     
+    private boolean isSelected = false;
     private boolean highlighted = false;
     private boolean traced = false;
     private boolean tracedStale = false;
@@ -90,8 +91,14 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         this.setPreferredSize(getSettings().getCellSize());
     }
     
+    public void setSelected(boolean selected) {
+        if(!tableView.getTable().isStaticDataTable() && this.isSelected != selected) {
+            this.isSelected = selected;
+        }
+    }
+    
     public boolean isSelected() {
-    	return dataCell.isSelected();
+    	return isSelected;
     }
     
     public boolean equals (DataCellView v) {
@@ -129,7 +136,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
 
         if(highlighted) {
             backgroundColor = settings.getHighlightColor();
-        } else if(dataCell.isSelected()) {
+        } else if(isSelected()) {
             backgroundColor = settings.getSelectColor();
         } else if(null == tableView.getTable().getCompareTable()) {
             backgroundColor = getBinColor();
@@ -243,7 +250,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
             }
         } else if (highlighted) {
             textColor = Settings.highlightTextColor;
-        } else if (dataCell.isSelected()) {
+        } else if (isSelected()) {
             textColor = Settings.selectTextColor;
         } else {
             textColor = Settings.scaleTextColor;
@@ -340,8 +347,8 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         if(isHighlighted()) {
             setHighlighted(false);
         }
-        if(dataCell.isSelected()) {
-        	dataCell.setSelected(false);
+        if(isSelected()) {
+        	setSelected(false);
         }
     }
 

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -126,8 +126,8 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         setBackground(getCellBackgroundColor());
         setForeground(getCellTextColor());
         setBorder(getCellBorder());
-        this.validate();
-        this.repaint();     
+        this.validate();   
+        super.repaint();
     }
 
     private Color getCellBackgroundColor() {

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -58,7 +58,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
     private int x = 0;
     private int y = 0;
     
-    private boolean isSelected = false;
+
     private boolean highlighted = false;
     private boolean traced = false;
     private boolean tracedStale = false;
@@ -91,18 +91,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         this.x = x;
         this.y = y;
     }
-    
-    public void setSelected(boolean selected) {
-        if(!tableView.getTable().isStaticDataTable() && this.isSelected != selected) {
-            this.isSelected = selected;
-            drawCell();
-        }
-    }
-    
-    public boolean isSelected() {
-    	return isSelected;
-    }
-    
+        
     public boolean equals (DataCellView v) {
     	return v.dataCell.equals(dataCell);
     }
@@ -138,7 +127,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
 
         if(highlighted) {
             backgroundColor = settings.getHighlightColor();
-        } else if(isSelected()) {
+        } else if(dataCell.isSelected()) {
             backgroundColor = settings.getSelectColor();
         } else if(null == tableView.getTable().getCompareTable()) {
             backgroundColor = getBinColor();
@@ -212,7 +201,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
     @Override
     public void mousePressed(MouseEvent e) {
         if (!e.isControlDown()) {
-        	tableView.clearSelection();
+        	dataCell.getTable().clearSelection();
         }
 
         if (e.isControlDown() && e.isAltDown()) {
@@ -252,7 +241,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
             }
         } else if (highlighted) {
             textColor = Settings.highlightTextColor;
-        } else if (isSelected()) {
+        } else if (dataCell.isSelected()) {
             textColor = Settings.selectTextColor;
         } else {
             textColor = Settings.scaleTextColor;
@@ -352,11 +341,14 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         if(isHighlighted()) {
             setHighlighted(false);
         }
-        if(isSelected()) {
-        	setSelected(false);
+        if(dataCell.isSelected()) {
+        	dataCell.setSelected(false);
         }
     }
-
+    
+    public boolean isSelected() {
+    	return dataCell.isSelected();
+    }
     
     @Override
     public String toString() {

--- a/src/main/java/com/romraider/maps/PresetPanel.java
+++ b/src/main/java/com/romraider/maps/PresetPanel.java
@@ -104,8 +104,10 @@ public class PresetPanel extends JPanel {
 		add(radioPanel, c);
 		
 		//Add description if its a switch
-		if(isSwitchTable) {
-			JTextArea desc = new JTextArea(table.getTable().getDescription());
+		String stringDesc = table.getTable().getDescription();
+		
+		if(isSwitchTable && stringDesc != null && stringDesc.trim().length() > 0) {
+			JTextArea desc = new JTextArea(stringDesc);
 			desc.setLineWrap(true);
 			desc.setWrapStyleWord(true);
 			desc.setOpaque(false);

--- a/src/main/java/com/romraider/maps/PresetPanel.java
+++ b/src/main/java/com/romraider/maps/PresetPanel.java
@@ -55,13 +55,18 @@ public class PresetPanel extends JPanel {
 		}
 				
 		JPanel radioPanel = new JPanel(new GridLayout(0, 1));
+		boolean isSwitchTable = table.getTable() instanceof TableSwitch;
 		
 		// Add presets
 		if(manager.getPresets().size() > 0) {
-			JLabel optionLabel = new JLabel(" Presets");
+			String s = isSwitchTable ? "Switch States    ": "Presets";
 			
+			JLabel optionLabel = new JLabel(s);
 			Font f = optionLabel.getFont();
-			optionLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD));		
+			if (isSwitchTable)
+				optionLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD, 15));
+			else
+				optionLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD));
 			radioPanel.add(optionLabel);
 		}
 		
@@ -72,6 +77,11 @@ public class PresetPanel extends JPanel {
 			button.setText(entry.name);
 			button.setPresetData(entry.data);
 
+			if (isSwitchTable) {
+				Font f = button.getFont();
+				button.setFont(f.deriveFont(f.getStyle(), 15));
+			}
+				
 			button.addActionListener(new PresetListener());
 			
 			buttonGroup.add(button);
@@ -111,7 +121,8 @@ public class PresetPanel extends JPanel {
 			if (values != null) {
 				for (int i = 0; i < table.getTable().getDataSize(); i++) {
 					if(table.getTable().getDataSize() == values.size()) {
-						if ((int) table.data[i].getDataCell().getBinValue() != values.get(i)) {
+						DataCell[] data = table.getTable().data;
+						if ((int) data[i].getBinValue() != values.get(i)) {
 							found = false;
 							break;
 						}
@@ -130,8 +141,9 @@ public class PresetPanel extends JPanel {
 			if(table.getTable().getDataSize() == button.values.size()) {
 				for (int i = 0; i < table.getTable().getDataSize(); i++) {
 					try {
-						table.data[i].getDataCell().setBinValue(button.values.get(i));
+						table.getTable().data[i].setBinValue(button.values.get(i));
 					} catch (UserLevelException e) {
+						e.printStackTrace();
 					}
 				}
 			}

--- a/src/main/java/com/romraider/maps/PresetPanel.java
+++ b/src/main/java/com/romraider/maps/PresetPanel.java
@@ -38,9 +38,9 @@ public class PresetPanel extends JPanel {
 	private static final long serialVersionUID = 1L;
 	private final List<PresetButton> buttonGroup = new ArrayList<PresetButton>();
 	private PresetManager manager;
-	private Table table;
+	private TableView table;
 	
-	public PresetPanel(Table t, PresetManager manager) {
+	public PresetPanel(TableView t, PresetManager manager) {
 		this.manager = manager;
 		this.table = t;
 	}
@@ -48,8 +48,8 @@ public class PresetPanel extends JPanel {
 	public void populatePanel() {
 		
 		//If this is an axis within another table dont show the panel
-		if(table instanceof Table1D) {
-			if(((Table1D) (table)).getAxisParent() != null) {
+		if(table.getTable() instanceof Table1D) {
+			if(((Table1D) (table.getTable())).getAxisParent() != null) {
 				return;
 			}
 		}
@@ -109,8 +109,8 @@ public class PresetPanel extends JPanel {
 			boolean found = true;
 			
 			if (values != null) {
-				for (int i = 0; i < table.getDataSize(); i++) {
-					if(table.getDataSize() == values.size()) {
+				for (int i = 0; i < table.getTable().getDataSize(); i++) {
+					if(table.getTable().getDataSize() == values.size()) {
 						if ((int) table.data[i].getDataCell().getBinValue() != values.get(i)) {
 							found = false;
 							break;
@@ -127,14 +127,14 @@ public class PresetPanel extends JPanel {
 		public void actionPerformed(ActionEvent event) {
 			PresetButton button = (PresetButton)event.getSource();
 			
-			if(table.getDataSize() == button.values.size()) {
-				for (int i = 0; i < table.getDataSize(); i++) {
+			if(table.getTable().getDataSize() == button.values.size()) {
+				for (int i = 0; i < table.getTable().getDataSize(); i++) {
 					table.data[i].getDataCell().setBinValue(button.values.get(i));
 				}
 			}
 			
-			table.calcCellRanges();
-			table.calcValueRange();
+			table.getTable().calcCellRanges();
+			table.getTable().calcValueRange();
 			repaint();
 		}
 	}

--- a/src/main/java/com/romraider/maps/PresetPanel.java
+++ b/src/main/java/com/romraider/maps/PresetPanel.java
@@ -66,11 +66,10 @@ public class PresetPanel extends JPanel {
 		radioPanel.setBorder(new EmptyBorder(0, 2, 7, 0));
 		boolean isSwitchTable = table.getTable() instanceof TableSwitch;
 
-		JLabel optionLabel = new JLabel();
-			
+		JLabel optionLabel = new JLabel();			
 		String s = isSwitchTable ? table.getName(): "Presets";
 		optionLabel.setText(s);
-		optionLabel.setPreferredSize(new Dimension(500, 20));		
+		optionLabel.setPreferredSize(new Dimension(minimumWidth, 20));		
 		
 		Font f = optionLabel.getFont();
 		if (isSwitchTable)

--- a/src/main/java/com/romraider/maps/PresetPanel.java
+++ b/src/main/java/com/romraider/maps/PresetPanel.java
@@ -20,7 +20,10 @@
 package com.romraider.maps;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -31,6 +34,8 @@ import java.util.List;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.border.EmptyBorder;
 
 import com.romraider.maps.PresetManager.PresetEntry;
 
@@ -39,10 +44,13 @@ public class PresetPanel extends JPanel {
 	private final List<PresetButton> buttonGroup = new ArrayList<PresetButton>();
 	private PresetManager manager;
 	private TableView table;
+	private final int minimumWidth = 500;
 	
 	public PresetPanel(TableView t, PresetManager manager) {
 		this.manager = manager;
 		this.table = t;
+		setBorder(new EmptyBorder(2, 2, 2, 2));
+		setLayout(new GridBagLayout());
 	}
 	
 	public void populatePanel() {
@@ -54,21 +62,23 @@ public class PresetPanel extends JPanel {
 			}
 		}
 				
-		JPanel radioPanel = new JPanel(new GridLayout(0, 1));
+		JPanel radioPanel = new JPanel(new GridLayout(0, 1));		
+		radioPanel.setBorder(new EmptyBorder(0, 2, 7, 0));
 		boolean isSwitchTable = table.getTable() instanceof TableSwitch;
-		
-		// Add presets
-		if(manager.getPresets().size() > 0) {
-			String s = isSwitchTable ? "Switch States    ": "Presets";
+
+		JLabel optionLabel = new JLabel();
 			
-			JLabel optionLabel = new JLabel(s);
-			Font f = optionLabel.getFont();
-			if (isSwitchTable)
-				optionLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD, 15));
-			else
-				optionLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD));
-			radioPanel.add(optionLabel);
-		}
+		String s = isSwitchTable ? table.getName(): "Presets";
+		optionLabel.setText(s);
+		optionLabel.setPreferredSize(new Dimension(500, 20));		
+		
+		Font f = optionLabel.getFont();
+		if (isSwitchTable)
+			optionLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD, 15));
+		else
+			optionLabel.setFont(f.deriveFont(f.getStyle() | Font.BOLD));
+	
+		radioPanel.add(optionLabel);
 		
 		//Setup button for each preset
 		for (PresetEntry entry : manager.getPresets()) {
@@ -78,17 +88,45 @@ public class PresetPanel extends JPanel {
 			button.setPresetData(entry.data);
 
 			if (isSwitchTable) {
-				Font f = button.getFont();
-				button.setFont(f.deriveFont(f.getStyle(), 15));
+				Font x = button.getFont();
+				button.setFont(x.deriveFont(x.getStyle(), 15));
 			}
 				
-			button.addActionListener(new PresetListener());
-			
+			button.addActionListener(new PresetListener());			
 			buttonGroup.add(button);
 			radioPanel.add(button);
 		}
-
-		table.add(radioPanel, BorderLayout.SOUTH);
+		
+		GridBagConstraints c = new GridBagConstraints();
+		c.fill = GridBagConstraints.BOTH;
+		c.anchor = GridBagConstraints.FIRST_LINE_START;
+		c.gridx = 0;       
+		c.gridy = 0;	
+		add(radioPanel, c);
+		
+		//Add description if its a switch
+		if(isSwitchTable) {
+			JTextArea desc = new JTextArea(table.getTable().getDescription());
+			desc.setLineWrap(true);
+			desc.setWrapStyleWord(true);
+			desc.setOpaque(false);
+	
+			Font x = optionLabel.getFont();
+			desc.setFont(x.deriveFont(x.getStyle(), 12));
+				
+			c.gridx = 0;        
+			c.gridy = 1;			
+			c.anchor = GridBagConstraints.LAST_LINE_START; 
+			add(desc, c);			
+		}
+		
+		//Move it to the bottom and left
+		//For sure better way to do this...
+		JPanel temp = new JPanel();
+		temp.setLayout(new BorderLayout());
+		temp.add(this, BorderLayout.WEST);
+		
+		table.add(temp, BorderLayout.SOUTH);
 		repaint();
 	}	
 	

--- a/src/main/java/com/romraider/maps/PresetPanel.java
+++ b/src/main/java/com/romraider/maps/PresetPanel.java
@@ -129,7 +129,10 @@ public class PresetPanel extends JPanel {
 			
 			if(table.getTable().getDataSize() == button.values.size()) {
 				for (int i = 0; i < table.getTable().getDataSize(); i++) {
-					table.data[i].getDataCell().setBinValue(button.values.get(i));
+					try {
+						table.data[i].getDataCell().setBinValue(button.values.get(i));
+					} catch (UserLevelException e) {
+					}
 				}
 			}
 			

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -232,7 +232,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
                                 table.getStorageAddress() + " " + binData.length + " filesize", iex);
 
                         // table storage address extends beyond end of file
-                        JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(table.getTableView()),
+                        JOptionPane.showMessageDialog(null,
                                 MessageFormat.format(rb.getString("ADDROUTOFBNDS"), table.getName()),
                                 rb.getString("ECUDEFERROR"), JOptionPane.ERROR_MESSAGE);
                         tableNodes.removeElementAt(i);

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -311,11 +311,13 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
     }
 
     //Most of this function is useless now, since each Datacell is now responsible for each memory region
-    //It is only used in the Switch Tables, since those don't use DataCells
+    //It is only used to correct the Subaru Checksum. Should be moved somewhere else TODO
     public byte[] saveFile() {
 
         final List<TableTreeNode> checksumTables = new ArrayList<TableTreeNode>();
         for (TableTreeNode tableNode : tableNodes) {
+        	
+        	//Only used in BitwiseSwitch Table...
             tableNode.getTable().saveFile(binData);
             if (tableNode.getTable().getName().contains("Checksum Fix")) {
                 checksumTables.add(tableNode);

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -120,7 +120,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
         boolean found = false;
 
         for (int i = 0; i < tableNodes.size(); i++) {
-            if (tableNodes.get(i).getTable().equals(table)) {
+            if (tableNodes.get(i).getTable().equalsWithoutData(table)) {
                 tableNodes.remove(i);
                 tableNodes.add(i, new TableTreeNode(table));
                 found = true;

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -84,8 +84,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
 
         // Add nodes to ROM tree.
         for (TableTreeNode tableTreeNode : tableNodes) {
-            TableFrame tableFrame = tableTreeNode.getFrame();
-            Table table = tableFrame.getTable();
+            Table table = tableTreeNode.getTable();
             String[] categories = table.getCategory().split("//");
                       
             if (settings.isDisplayHighTables() || settings.getUserLevel() >= table.getUserLevel()) {
@@ -119,18 +118,17 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
 
     public void addTable(Table table) {
         boolean found = false;
-        String frameTitle = this.getFileName()+" - " + table.getName();
 
         for (int i = 0; i < tableNodes.size(); i++) {
             if (tableNodes.get(i).getTable().equals(table)) {
                 tableNodes.remove(i);
-                tableNodes.add(i, new TableTreeNode(new TableFrame(frameTitle, table)));
+                tableNodes.add(i, new TableTreeNode(table));
                 found = true;
                 break;
             }
         }
         if (!found) {
-            tableNodes.add(new TableTreeNode(new TableFrame(frameTitle, table)));
+            tableNodes.add(new TableTreeNode(table));
         }
     }
 
@@ -141,13 +139,13 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
         for (int i = 0; i < tableNodes.size(); i++) {
             if (tableNodes.get(i).getTable().getName().equalsIgnoreCase(table.getName())) {
                 tableNodes.remove(i);
-                tableNodes.add(i, new TableTreeNode(new TableFrame(frameTitle, table)));
+                tableNodes.add(i, new TableTreeNode(table));
                 found = true;
                 break;
             }
         }
         if (!found) {
-            tableNodes.add(new TableTreeNode(new TableFrame(frameTitle, table)));
+            tableNodes.add(new TableTreeNode(table));
         }
     }
 

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -410,10 +410,6 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
     public void setFullFileName(File fullFileName) {
         this.fullFileName = fullFileName;
         this.setFileName(fullFileName.getName());
-        for (TableTreeNode tableNode : tableNodes) {
-            String frameTitle = this.getFileName() + " - " + tableNode.getTable().getName();
-            tableNode.getFrame().setTitle(frameTitle);
-        }
     }
 
     public boolean isAbstract() {
@@ -426,7 +422,8 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
 
     public void refreshTableCompareMenus() {
         for(TableTreeNode tableNode : getTableNodes()) {
-            tableNode.getFrame().refreshSimilarOpenTables();
+        	TableFrame f = tableNode.getFrame();
+        	if(f != null) f.refreshSimilarOpenTables();
         }
     }
 

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -134,7 +134,6 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
 
     public void addTableByName(Table table) {
         boolean found = false;
-        String frameTitle = this.getFileName()+" - "+table.getName();
 
         for (int i = 0; i < tableNodes.size(); i++) {
             if (tableNodes.get(i).getTable().getName().equalsIgnoreCase(table.getName())) {
@@ -402,7 +401,8 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
                 frame.setTableView(null);
             }
         }
-
+        
+        checksumManagers.clear();
         tableNodes.clear();
         binData = null;
     }
@@ -472,10 +472,8 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
     }
 
     public void updateChecksum() {
-        if (!checksumManagers.isEmpty()) {
-            for(ChecksumManager cm: checksumManagers) {
-            	cm.update(binData);
-            }
+        for(ChecksumManager cm: checksumManagers) {
+        	cm.update(binData);
         }
     }
 }

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -119,7 +119,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
 
     public void addTable(Table table) {
         boolean found = false;
-        String frameTitle = this.getFileName()+" - "+table.getName();
+        String frameTitle = this.getFileName()+" - " + table.getName();
 
         for (int i = 0; i < tableNodes.size(); i++) {
             if (tableNodes.get(i).getTable().equals(table)) {

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -216,7 +216,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
                                 table.getStorageAddress() + " " + binData.length + " filesize", ex);
 
                         // table storage address extends beyond end of file
-                        JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(table),
+                        JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(table.getTableView()),
                                 MessageFormat.format(rb.getString("ADDROUTOFBNDS"), table.getName()),
                                 rb.getString("ECUDEFERROR"), JOptionPane.ERROR_MESSAGE);
                         tableNodes.removeElementAt(i);
@@ -227,7 +227,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
                                 table.getStorageAddress() + " " + binData.length + " filesize", iex);
 
                         // table storage address extends beyond end of file
-                        JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(table),
+                        JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(table.getTableView()),
                                 MessageFormat.format(rb.getString("ADDROUTOFBNDS"), table.getName()),
                                 rb.getString("ECUDEFERROR"), JOptionPane.ERROR_MESSAGE);
                         tableNodes.removeElementAt(i);
@@ -242,7 +242,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
 
             } catch (NullPointerException ex) {
                 LOGGER.error("Error Populating Table", ex);
-                JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(table),
+                JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(table.getTableView()),
                         MessageFormat.format(rb.getString("TABLELOADERR"), table.getName()),
                         rb.getString("ECUDEFERROR"), JOptionPane.ERROR_MESSAGE);
                 tableNodes.removeElementAt(i);
@@ -360,7 +360,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
                 Object[] options = {rb.getString("YES"), rb.getString("NO")};
                 final String message = rb.getString("CHKSUMINVALID");
                 int answer = showOptionDialog(
-                        SwingUtilities.windowForComponent(checksum.getTable()),
+                        SwingUtilities.windowForComponent(checksum.getTable().getTableView()),
                         message,
                         rb.getString("CHECKSUMFIX"),
                         DEFAULT_OPTION,

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -386,13 +386,21 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
         // Hide and dispose all frames.
         for(TableTreeNode tableTreeNode : tableNodes) {
             TableFrame frame = tableTreeNode.getFrame();
-            frame.setVisible(false);
-            try {
-                frame.setClosed(true);
-            } catch (PropertyVetoException e) {
-                ; // Do nothing.
+        
+            if(frame != null) {
+            	frame.getTableView().setVisible(false);            
+	            frame.setVisible(false);
+	            
+	            try {
+	                frame.setClosed(true);
+	            } catch (PropertyVetoException e) {
+	                ; // Do nothing.
+	            }
+	            frame.dispose();
+	            
+                frame.getTableView().setTable(null);
+                frame.setTableView(null);
             }
-            frame.dispose();
         }
 
         tableNodes.clear();

--- a/src/main/java/com/romraider/maps/Rom.java
+++ b/src/main/java/com/romraider/maps/Rom.java
@@ -85,6 +85,7 @@ public class Rom extends DefaultMutableTreeNode implements Serializable  {
         // Add nodes to ROM tree.
         for (TableTreeNode tableTreeNode : tableNodes) {
             Table table = tableTreeNode.getTable();
+                       
             String[] categories = table.getCategory().split("//");
                       
             if (settings.isDisplayHighTables() || settings.getUserLevel() >= table.getUserLevel()) {

--- a/src/main/java/com/romraider/maps/Scale.java
+++ b/src/main/java/com/romraider/maps/Scale.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2017 RomRaider.com
+ * Copyright (C) 2006-2021 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,7 +38,6 @@ public class Scale implements Serializable {
     private double fineIncrement = 1;
     private double min = 0.0;
     private double max = 0.0;
-
 
     @Override
     public String toString() {

--- a/src/main/java/com/romraider/maps/Scale.java
+++ b/src/main/java/com/romraider/maps/Scale.java
@@ -23,6 +23,8 @@ package com.romraider.maps;
 
 import java.io.Serializable;
 
+import com.romraider.util.JEPUtil;
+
 public class Scale implements Serializable {
 
     private static final long serialVersionUID = 5836610685159474795L;
@@ -37,8 +39,6 @@ public class Scale implements Serializable {
     private double min = 0.0;
     private double max = 0.0;
 
-    public Scale() {
-    }
 
     @Override
     public String toString() {
@@ -54,7 +54,17 @@ public class Scale implements Serializable {
                 "\n      Max: " + getMax() +
                 "\n      ---- End Scale ----\n";
     }
+    
+    public boolean validate() {
+        double startValue = 5;
+        double toReal = JEPUtil.evaluate(getExpression(), startValue); // convert real world value of "5"
+        double endValue = JEPUtil.evaluate(getByteExpression(), toReal);
 
+        // if real to byte doesn't equal 5, report conflict
+        if (Math.abs(endValue - startValue) > .001) return false;
+        else return true;
+    }
+    
     public String getUnit() {
         return unit;
     }

--- a/src/main/java/com/romraider/maps/Scale.java
+++ b/src/main/java/com/romraider/maps/Scale.java
@@ -55,6 +55,8 @@ public class Scale implements Serializable {
     }
     
     public boolean validate() {
+    	if(expression.equals("x") && byteExpression.equals("x")) return true;
+    	
         double startValue = 5;
         double toReal = JEPUtil.evaluate(getExpression(), startValue); // convert real world value of "5"
         double endValue = JEPUtil.evaluate(getByteExpression(), toReal);

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -304,9 +304,9 @@ public abstract class Table implements Serializable {
         }
         return output;
     }
-
-    @Override
-    public boolean equals(Object other) {
+    
+    //Faster version of equals where data doesnt matter (yet)
+    public boolean equalsWithoutData(Object other) {
         try {
             if(null == other) {
                 return false;
@@ -321,7 +321,15 @@ public abstract class Table implements Serializable {
             }
 
             Table otherTable = (Table)other;
-
+            
+            if(storageAddress != otherTable.storageAddress) {
+            	return false;
+            }
+            
+            if(!this.name.equals(otherTable.name)) {
+            	return false;
+            }
+            
             if(this.data.length != otherTable.data.length)
             {
                 return false;
@@ -330,12 +338,22 @@ public abstract class Table implements Serializable {
 			if (this.bitMask != otherTable.bitMask) {
 				return false;
 			}
-			
-            if(this.data.equals(otherTable.data))
-            {
-                return true;
-            }
-
+			         
+            return true;
+        } catch(Exception ex) {
+            // TODO: Log Exception.
+            return false;
+        }
+    }
+    
+    @Override
+    public boolean equals(Object other) {
+        try {
+            boolean withoutData = equalsWithoutData(other);
+            if(!withoutData) return false;
+            
+            Table otherTable = (Table)other;
+            
             // Compare Bin Values
             for(int i=0 ; i < this.data.length ; i++) {
                 if(! this.data[i].equals(otherTable.data[i])) {

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -118,7 +118,9 @@ public abstract class Table implements Serializable {
     }
     
     public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
-        // temporarily remove lock;
+    	validateScaling();
+    	
+    	// temporarily remove lock;
         boolean tempLock = locked;
         locked = false;
 
@@ -199,8 +201,6 @@ public abstract class Table implements Serializable {
         if(SettingsManager.getSettings().getDefaultScale().equalsIgnoreCase(scale.getName())) {
             this.curScale = scale;
         }
-
-        validateScaling();
     }
 
     public int getStorageAddress() {
@@ -580,13 +580,7 @@ public abstract class Table implements Serializable {
 	}
     
     public void validateScaling() {
-        if (getType() != TableType.SWITCH) {
-
-            // make sure a scale is present
-            if (scales.isEmpty()) {
-                scales.add(new Scale());
-            }
-            
+        if (getType() != TableType.SWITCH) {            
             for(Scale scale : scales) {
                 if (!scale.validate()) {
                 	TableView.showBadScalePopup(this, scale);

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -27,9 +27,7 @@ import javax.naming.NameNotFoundException;
 import org.apache.log4j.Logger;
 
 import com.romraider.Settings;
-import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.swing.TableFrame;
-import com.romraider.swing.TableToolBar;
 import com.romraider.util.ByteUtil;
 import com.romraider.util.JEPUtil;
 import com.romraider.util.NumberUtil;
@@ -610,24 +608,14 @@ public abstract class Table implements Serializable {
         if(y >= 0 && y < data.length) {
             clearSelection();
             data[y].setSelected(true);
-            if(tableView!=null) tableView.highlightY = y;
-            
-            TableToolBar bar = ECUEditorManager.getECUEditor().getTableToolBar();
-            
-            if(bar!=null)
-            	bar.updateTableToolBar(this);
+            if(tableView!=null) tableView.highlightY = y;          
         }
     }
 
     public void selectCellAtWithoutClear(int y) {
         if(y >= 0 && y < data.length) {
             data[y].setSelected(true);
-            if(tableView!=null)tableView.highlightY = y;
-            
-            TableToolBar bar = ECUEditorManager.getECUEditor().getTableToolBar();
-            
-            if(bar!=null)
-            	bar.updateTableToolBar(this);
+            if(tableView!=null)tableView.highlightY = y;            
         }
     }
     

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -37,6 +37,8 @@ public abstract class Table implements Serializable {
     protected static final String ST_DELIMITER = "\t\n\r\f";
     protected static Settings.Endian memModelEndian;
 
+    protected TableView tableView;
+    
     protected String name;
     protected String category = "Other";
     protected String description = Settings.BLANK;
@@ -83,7 +85,14 @@ public abstract class Table implements Serializable {
         scales.clear();     
     };
 
-       
+    public void setTableView(TableView v) {
+    	this.tableView = v;
+    }
+    
+    public TableView getTableView() {
+    	return this.tableView;
+    }
+    
     public DataCell[] getData() {
         return data;
     }
@@ -239,6 +248,10 @@ public abstract class Table implements Serializable {
 
     public String getLogParam() {
         return logParam;
+    }
+    
+    public String getLogParamString() {
+        return getName()+ ":" + getLogParam();
     }
 
     @Override
@@ -459,64 +472,7 @@ public abstract class Table implements Serializable {
         this.minCompare = minCompare;
     }
 
-    //TODO: Rework
-    //Cell should check if selected and then increment
-    public void increment(double increment) throws UserLevelException {
-        if (!locked && !(userLevel > getSettings().getUserLevel())) {
-            for (DataCell cell : data) {
-                if (cell.isSelected()) {
-                    cell.increment(increment);
-                }
-            }
-        } else if (userLevel > getSettings().getUserLevel()) {
-        	throw new UserLevelException(userLevel);
-        	/*
-            JOptionPane.showMessageDialog(this, MessageFormat.format(
-                    rb.getString("USERLVLTOLOW"), userLevel),
-                    rb.getString("TBLNOTMODIFY"),
-                    JOptionPane.INFORMATION_MESSAGE);*/
-        }
-    }
-
-    public void multiply(double factor) throws UserLevelException{
-    	
-        if (!locked && !(userLevel > getSettings().getUserLevel())) {
-            for (DataCell cell : data) {
-                if (cell.isSelected()) {
-                	
-                	//Use raw or real value, depending on view settings
-                	if(getCurrentScale().getName().equals("Raw Value"))
-                		cell.multiplyRaw(factor);                	
-                	else 
-                		cell.multiply(factor);               	
-                }
-            }
-        } else if (userLevel > getSettings().getUserLevel()) {
-        	throw new UserLevelException(userLevel);
-        	/*
-            JOptionPane.showMessageDialog(this, MessageFormat.format(
-                    rb.getString("USERLVLTOLOW"), userLevel),
-                    rb.getString("TBLNOTMODIFY"),
-                    JOptionPane.INFORMATION_MESSAGE);*/
-        }
-    }
-
-    public void setRealValue(String realValue) throws UserLevelException {
-        if (!locked && userLevel <= getSettings().getUserLevel()) {
-            for(DataCell cell : data) {
-                if (cell.isSelected()) {
-                    cell.setRealValue(realValue);
-                }
-            }
-        } else if (userLevel > getSettings().getUserLevel()) {
-        	throw new UserLevelException(userLevel);
-        	/*
-            JOptionPane.showMessageDialog(this, MessageFormat.format(
-                    rb.getString("USERLVLTOLOW"), userLevel),
-                    rb.getString("TBLNOTMODIFY"),
-                    JOptionPane.INFORMATION_MESSAGE);*/
-        }
-    }
+    
 
 
     public void setRevertPoint() {
@@ -525,21 +481,12 @@ public abstract class Table implements Serializable {
         }
     }
 
-    public void undoAll() {
+    public void undoAll() throws UserLevelException {
         for (DataCell cell : data) {
             cell.undo();
         }
     }
-    
-    public void undoSelected() {
-        for (DataCell cell : data) {
-            // reset current value to original value
-            if (cell.isSelected()) {
-                cell.undo();
-            }
-        }
-    }
-  
+     
     abstract public byte[] saveFile(byte[] binData);
     
     public void setValues(String name, String value) {
@@ -589,21 +536,6 @@ public abstract class Table implements Serializable {
 		return bitMask;
 	}
     
-
-    public void verticalInterpolate() {
-    }
-
-    public void horizontalInterpolate() {
-    }
-
-    public void interpolate() {
-        horizontalInterpolate();
-    }
-    
-    public double linearInterpolation(double x, double x1, double x2, double y1, double y2) {
-        return (x1 == x2) ? 0.0 : (y1 + (x - x1) * (y2 - y1) / (x2 - x1));
-    }
-
     public void validateScaling() {
         if (getType() != TableType.SWITCH) {
 

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -260,7 +260,9 @@ public abstract class Table implements Serializable {
         return name;
     }
     
-
+    public String getName() {
+    	return toString();
+    }
 
     @Override
     public boolean equals(Object other) {
@@ -639,7 +641,8 @@ public abstract class Table implements Serializable {
     }
 
 
-
+    public abstract boolean isLiveDataSupported();
+    
     public int getUserLevel() {
         return userLevel;
     }

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -500,9 +500,6 @@ public abstract class Table implements Serializable {
         this.minCompare = minCompare;
     }
 
-    
-
-
     public void setRevertPoint() {
         for (DataCell cell : data) {
             cell.setRevertPoint();
@@ -632,8 +629,6 @@ public abstract class Table implements Serializable {
 
     public void setCurrentScale(Scale curScale) {
         this.curScale = curScale;
-        
-        if(tableView!=null) tableView.repaint();
     }
 
     public Settings getSettings()

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -108,16 +108,29 @@ public abstract class Table implements Serializable {
         return data;
     }
 
+    //Cleans up all references to avoid data leaks
+    public void clearData() {
+    	
+    	for(int i=0;i<getDataSize();i++) {
+    		if(data[i]!=null) {
+	    		data[i].setTable(null);
+	    		data[i].setRom(null);
+	    		data[i] = null;
+    		}
+    	}
+    	
+    	data = null;
+    }
+    
     public void setData(DataCell[] data) {
         this.data = data;
     }
-    
-    
+     
     public int getRamOffset() {
     	return this.ramOffset;
     }
     
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+    public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
     	validateScaling();
     	
     	// temporarily remove lock;
@@ -125,11 +138,11 @@ public abstract class Table implements Serializable {
         locked = false;
 
         if (!beforeRam) {
-            this.ramOffset = romRamOffset;
+            this.ramOffset = rom.getRomID().getRamOffset();
         }
 
         for (int i = 0; i < data.length; i++) {          	
-        	data[i] = new DataCell(this, i, input);    
+        	data[i] = new DataCell(this, i, rom);    
         }
 
         // reset locked status

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -131,6 +131,8 @@ public abstract class Table implements Serializable {
     }
     
     public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+    	if(isStaticDataTable()) return;
+    	
     	validateScaling();
     	
     	// temporarily remove lock;

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -118,7 +118,6 @@ public abstract class Table implements Serializable {
     };
 
        
-
     public DataCell[] getData() {
         return data;
     }
@@ -559,6 +558,15 @@ public abstract class Table implements Serializable {
     public void undoAll() {
         for (DataCell cell : data) {
             cell.undo();
+        }
+    }
+    
+    public void undoSelected() {
+        for (DataCell cell : data) {
+            // reset current value to original value
+            if (cell.isSelected()) {
+                cell.undo();
+            }
         }
     }
   

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -595,6 +595,7 @@ public abstract class Table implements Serializable {
         }
 
         calcCellRanges();
+        if(tableView != null) tableView.drawTable();
     }
 
 
@@ -651,7 +652,7 @@ public abstract class Table implements Serializable {
     }
 
     public void setCompareTable(Table compareTable) {
-        this.compareTable = compareTable;
+        this.compareTable = compareTable;     
     }
 
     public void setCompareValueType(Settings.DataType compareValueType) {

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -126,10 +126,8 @@ public abstract class Table implements Serializable {
             this.ramOffset = romRamOffset;
         }
 
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] == null) {            	
-            	data[i] = new DataCell(this, i, input);    
-            }
+        for (int i = 0; i < data.length; i++) {          	
+        	data[i] = new DataCell(this, i, input);    
         }
 
         // reset locked status
@@ -290,7 +288,7 @@ public abstract class Table implements Serializable {
     }
     
     public String getName() {
-    	return toString();
+    	return name;
     }
     
     public StringBuffer getTableAsString() {
@@ -634,6 +632,8 @@ public abstract class Table implements Serializable {
 
     public void setCurrentScale(Scale curScale) {
         this.curScale = curScale;
+        
+        if(tableView!=null) tableView.repaint();
     }
 
     public Settings getSettings()

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -41,28 +41,20 @@ import java.util.StringTokenizer;
 import java.util.Vector;
 
 import javax.naming.NameNotFoundException;
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.InputMap;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.KeyStroke;
+
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 import org.apache.log4j.Logger;
 
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
-import com.romraider.swing.TableToolBar;
 import com.romraider.util.ByteUtil;
 import com.romraider.util.JEPUtil;
 import com.romraider.util.NumberUtil;
 import com.romraider.util.ResourceUtil;
 import com.romraider.util.SettingsManager;
 
-public abstract class Table extends JPanel implements Serializable {
+public abstract class Table implements Serializable {
     private static final long serialVersionUID = 6559256489995552645L;
     protected static final Logger LOGGER = Logger.getLogger(Table.class);
     private static final ResourceBundle rb = new ResourceUtil().getBundle(
@@ -76,40 +68,27 @@ public abstract class Table extends JPanel implements Serializable {
     protected Vector<Scale> scales = new Vector<Scale>();
     protected Scale curScale;
     protected PresetManager presetManager;
-    protected PresetPanel presetPanel;
-        
+       
     protected int storageAddress;
     protected int storageType;
     protected boolean signed;
     protected Settings.Endian endian = Settings.Endian.BIG;
     protected boolean flip;
-    protected DataCellView[] data = new DataCellView[1];
+    
+    protected DataLayout dataLayout = DataLayout.DEFAULT;	//DataCell Ordering
+    protected byte[] input; 								//Pointer to Raw ROM Bytes
+    protected DataCell[] data = new DataCell[1];
+    
     protected boolean beforeRam = false;
     protected int ramOffset = 0;
-    protected BorderLayout borderLayout = new BorderLayout();
-    protected GridLayout centerLayout = new GridLayout(1, 1, 0, 0);
-    protected JPanel centerPanel = new JPanel(centerLayout);
-    protected JLabel tableLabel;
-    protected int verticalOverhead = 103;
-    protected int horizontalOverhead = 2;
-    protected int cellHeight = (int) getSettings().getCellSize().getHeight();
-    protected int cellWidth = (int) getSettings().getCellSize().getWidth();
-    protected int minHeight = 100;
-    protected int minWidthNoOverlay = 465;
-    protected int minWidthOverlay = 700;
-    protected int highlightX;
-    protected int highlightY;
-    protected boolean highlight = false;
+    
     protected int userLevel = 0;
     protected boolean locked = false;
-
     protected String logParam = Settings.BLANK;
-    protected boolean overlayLog = false;
 
     protected CopyTableWorker copyTableWorker;
     protected CopySelectionWorker copySelectionWorker;
 
-    protected byte[] input; //Pointer to Raw ROM Bytes
 	private int bitMask = 0;
 	
     protected double minAllowedBin = 0.0;
@@ -121,15 +100,12 @@ public abstract class Table extends JPanel implements Serializable {
     protected double maxCompare = 0.0;
     protected double minCompare = 0.0;
 
-    protected Settings.CompareDisplay compareDisplay = Settings.CompareDisplay.ABSOLUTE;
-    protected Settings.DataType compareValueType = Settings.DataType.BIN;
-
     protected boolean staticDataTable = false;
     protected String liveAxisValue = Settings.BLANK;
     protected int liveDataIndex = 0;
     protected int previousLiveDataIndex = 0;
     
-    protected DataLayout dataLayout = DataLayout.DEFAULT;
+    protected Settings.DataType compareValueType = Settings.DataType.BIN;
     private Table compareTable = null;
     
     public enum DataLayout {
@@ -138,373 +114,16 @@ public abstract class Table extends JPanel implements Serializable {
     }
     
     protected Table() {
-        scales.clear();
+        scales.clear();     
+    };
 
-        this.setLayout(borderLayout);
-        this.add(centerPanel, BorderLayout.CENTER);
-        centerPanel.setVisible(true);
-             
-        // key binding actions
-        Action rightAction = new AbstractAction() {
-            private static final long serialVersionUID = 1042884198300385041L;
+       
 
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                cursorRight();
-            }
-        };
-        Action leftAction = new AbstractAction() {
-            private static final long serialVersionUID = -4970441255677214171L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                cursorLeft();
-            }
-        };
-        Action downAction = new AbstractAction() {
-            private static final long serialVersionUID = -7898502951121825984L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                cursorDown();
-            }
-        };
-        Action upAction = new AbstractAction() {
-            private static final long serialVersionUID = 6937621541727666631L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                cursorUp();
-            }
-        };
-        Action shiftRightAction = new AbstractAction() {
-            private static final long serialVersionUID = 1042888914300385041L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                shiftCursorRight();
-            }
-        };
-        Action shiftLeftAction = new AbstractAction() {
-            private static final long serialVersionUID = -4970441655277214171L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-            	shiftCursorLeft();
-            }
-        };
-        Action shiftDownAction = new AbstractAction() {
-            private static final long serialVersionUID = -7898502951812125984L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-            	shiftCursorDown();
-            }
-        };
-        Action shiftUpAction = new AbstractAction() {
-            private static final long serialVersionUID = 6937621527147666631L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-            	shiftCursorUp();
-            }
-        };
-        Action incCoarseAction = new AbstractAction() {
-            private static final long serialVersionUID = -8308522736529183148L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().incrementCoarse();
-            }
-        };
-        Action decCoarseAction = new AbstractAction() {
-            private static final long serialVersionUID = -7407628920997400915L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().decrementCoarse();
-            }
-        };
-        Action incFineAction = new AbstractAction() {
-            private static final long serialVersionUID = 7261463425941761433L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().incrementFine();
-            }
-        };
-        Action decFineAction = new AbstractAction() {
-            private static final long serialVersionUID = 8929400237520608035L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().decrementFine();
-            }
-        };
-        Action num0Action = new AbstractAction() {
-            private static final long serialVersionUID = -6310984176739090034L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('0');
-            }
-        };
-        Action num1Action = new AbstractAction() {
-            private static final long serialVersionUID = -6187220355403883499L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('1');
-            }
-        };
-        Action num2Action = new AbstractAction() {
-            private static final long serialVersionUID = -8745505977907325720L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('2');
-            }
-        };
-        Action num3Action = new AbstractAction() {
-            private static final long serialVersionUID = 4694872385823448942L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('3');
-            }
-        };
-        Action num4Action = new AbstractAction() {
-            private static final long serialVersionUID = 4005741329254221678L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('4');
-            }
-        };
-        Action num5Action = new AbstractAction() {
-            private static final long serialVersionUID = -5846094949106279884L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('5');
-            }
-        };
-        Action num6Action = new AbstractAction() {
-            private static final long serialVersionUID = -5338656374925334150L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('6');
-            }
-        };
-        Action num7Action = new AbstractAction() {
-            private static final long serialVersionUID = 1959983381590509303L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('7');
-            }
-        };
-        Action num8Action = new AbstractAction() {
-            private static final long serialVersionUID = 7442763278699460648L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('8');
-            }
-        };
-        Action num9Action = new AbstractAction() {
-            private static final long serialVersionUID = 7475171864584215094L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('9');
-            }
-        };
-        Action numPointAction = new AbstractAction() {
-            private static final long serialVersionUID = -4729135055857591830L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('.');
-            }
-        };
-        Action copyAction = new AbstractAction() {
-            private static final long serialVersionUID = -6978981449261938672L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                copySelection();
-            }
-        };
-        Action pasteAction = new AbstractAction() {
-            private static final long serialVersionUID = 2026817603236490899L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                paste();
-            }
-        };
-        Action interpolate = new AbstractAction() {
-            private static final long serialVersionUID = -2357532575392447149L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                interpolate();
-            }
-        };
-        Action verticalInterpolate = new AbstractAction() {
-            private static final long serialVersionUID = -2375322575392447149L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                verticalInterpolate();
-            }
-        };
-        Action horizontalInterpolate = new AbstractAction() {
-            private static final long serialVersionUID = -6346750245035640773L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                horizontalInterpolate();
-            }
-        };
-        Action multiplyAction = new AbstractAction() {
-            private static final long serialVersionUID = -2753212575392447149L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().multiply();
-            }
-        };
-        Action numNegAction = new AbstractAction() {
-            private static final long serialVersionUID = -7532750245035640773L;
-
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                getToolbar().focusSetValue('-');
-            }
-        };
-
-        // set input mapping
-        InputMap im = getInputMap(WHEN_IN_FOCUSED_WINDOW);
-
-        KeyStroke right = KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0);
-        KeyStroke left = KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0);
-        KeyStroke up = KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0);
-        KeyStroke down = KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0);
-        KeyStroke shiftRight = KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.SHIFT_DOWN_MASK);
-        KeyStroke shiftLeft = KeyStroke.getKeyStroke(KeyEvent.VK_LEFT,  KeyEvent.SHIFT_DOWN_MASK);
-        KeyStroke shiftUp = KeyStroke.getKeyStroke(KeyEvent.VK_UP,  KeyEvent.SHIFT_DOWN_MASK);
-        KeyStroke shiftDown = KeyStroke.getKeyStroke(KeyEvent.VK_DOWN,  KeyEvent.SHIFT_DOWN_MASK);
-        KeyStroke decrement = KeyStroke.getKeyStroke('-');
-        KeyStroke increment = KeyStroke.getKeyStroke('+');
-        KeyStroke decrement2 = KeyStroke.getKeyStroke("control DOWN");
-        KeyStroke increment2 = KeyStroke.getKeyStroke("control UP");
-        KeyStroke decrement3 = KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, KeyEvent.CTRL_DOWN_MASK);
-        KeyStroke increment3 = KeyStroke.getKeyStroke(KeyEvent.VK_PLUS, KeyEvent.CTRL_DOWN_MASK);
-        KeyStroke decrement4 = KeyStroke.getKeyStroke("control shift DOWN");
-        KeyStroke increment4 = KeyStroke.getKeyStroke("control shift UP");
-        KeyStroke num0 = KeyStroke.getKeyStroke('0');
-        KeyStroke num1 = KeyStroke.getKeyStroke('1');
-        KeyStroke num2 = KeyStroke.getKeyStroke('2');
-        KeyStroke num3 = KeyStroke.getKeyStroke('3');
-        KeyStroke num4 = KeyStroke.getKeyStroke('4');
-        KeyStroke num5 = KeyStroke.getKeyStroke('5');
-        KeyStroke num6 = KeyStroke.getKeyStroke('6');
-        KeyStroke num7 = KeyStroke.getKeyStroke('7');
-        KeyStroke num8 = KeyStroke.getKeyStroke('8');
-        KeyStroke num9 = KeyStroke.getKeyStroke('9');
-        KeyStroke mulKey = KeyStroke.getKeyStroke('*');
-        KeyStroke mulKeys = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, KeyEvent.CTRL_DOWN_MASK);
-        KeyStroke numPoint = KeyStroke.getKeyStroke('.');
-        KeyStroke copy = KeyStroke.getKeyStroke("control C");
-        KeyStroke paste = KeyStroke.getKeyStroke("control V");
-        KeyStroke interp = KeyStroke.getKeyStroke("shift I");
-        KeyStroke vinterp = KeyStroke.getKeyStroke("shift V");
-        KeyStroke hinterp = KeyStroke.getKeyStroke("shift H");
-        KeyStroke numNeg = KeyStroke.getKeyStroke('-');
-
-        im.put(right, "right");
-        im.put(left, "left");
-        im.put(up, "up");
-        im.put(down, "down");
-        im.put(shiftRight, "shiftRight");
-        im.put(shiftLeft, "shiftLeft");
-        im.put(shiftUp, "shiftUp");
-        im.put(shiftDown, "shiftDown");
-        im.put(increment, "incCoarseAction");
-        im.put(decrement, "decCoarseAction");
-        im.put(increment2, "incCoarseAction");
-        im.put(decrement2, "decCoarseAction");
-        im.put(increment3, "incFineAction");
-        im.put(decrement3, "decFineAction");
-        im.put(increment4, "incFineAction");
-        im.put(decrement4, "decFineAction");
-        im.put(num0, "num0Action");
-        im.put(num1, "num1Action");
-        im.put(num2, "num2Action");
-        im.put(num3, "num3Action");
-        im.put(num4, "num4Action");
-        im.put(num5, "num5Action");
-        im.put(num6, "num6Action");
-        im.put(num7, "num7Action");
-        im.put(num8, "num8Action");
-        im.put(num9, "num9Action");
-        im.put(numPoint, "numPointAction");
-        im.put(copy, "copyAction");
-        im.put(paste, "pasteAction");
-        im.put(interp, "interpolate");
-        im.put(vinterp, "verticalInterpolate");
-        im.put(hinterp, "horizontalInterpolate");
-        im.put(mulKey, "mulAction");
-        im.put(mulKeys, "mulAction");
-        im.put(numNeg, "numNeg");
-
-        getActionMap().put(im.get(right), rightAction);
-        getActionMap().put(im.get(left), leftAction);
-        getActionMap().put(im.get(up), upAction);
-        getActionMap().put(im.get(down), downAction);
-        getActionMap().put(im.get(shiftRight), shiftRightAction);
-        getActionMap().put(im.get(shiftLeft), shiftLeftAction);
-        getActionMap().put(im.get(shiftUp), shiftUpAction);
-        getActionMap().put(im.get(shiftDown), shiftDownAction);
-        getActionMap().put(im.get(increment), incCoarseAction);
-        getActionMap().put(im.get(decrement), decCoarseAction);
-        getActionMap().put(im.get(increment2), incCoarseAction);
-        getActionMap().put(im.get(decrement2), decCoarseAction);
-        getActionMap().put(im.get(increment3), incFineAction);
-        getActionMap().put(im.get(decrement3), decFineAction);
-        getActionMap().put(im.get(increment4), incFineAction);
-        getActionMap().put(im.get(decrement4), decFineAction);
-        getActionMap().put(im.get(num0), num0Action);
-        getActionMap().put(im.get(num1), num1Action);
-        getActionMap().put(im.get(num2), num2Action);
-        getActionMap().put(im.get(num3), num3Action);
-        getActionMap().put(im.get(num4), num4Action);
-        getActionMap().put(im.get(num5), num5Action);
-        getActionMap().put(im.get(num6), num6Action);
-        getActionMap().put(im.get(num7), num7Action);
-        getActionMap().put(im.get(num8), num8Action);
-        getActionMap().put(im.get(num9), num9Action);
-        getActionMap().put(im.get(numPoint), numPointAction);
-        getActionMap().put(im.get(mulKey), multiplyAction);
-        getActionMap().put(im.get(mulKeys), multiplyAction);
-        getActionMap().put(im.get(copy), copyAction);
-        getActionMap().put(im.get(paste), pasteAction);
-        getActionMap().put(im.get(interp), interpolate);
-        getActionMap().put(im.get(vinterp), verticalInterpolate);
-        getActionMap().put(im.get(hinterp), horizontalInterpolate);
-        getActionMap().put(im.get(numNeg), numNegAction);
-
-        this.setInputMap(WHEN_FOCUSED, im);
-    }
-
-    public DataCellView[] getData() {
+    public DataCell[] getData() {
         return data;
     }
 
-    public void setData(DataCellView[] data) {
+    public void setData(DataCell[] data) {
         this.data = data;
     }
     
@@ -528,15 +147,7 @@ public abstract class Table extends JPanel implements Serializable {
 
         for (int i = 0; i < data.length; i++) {
             if (data[i] == null) {            	
-            	DataCell newC = new DataCell(this, i);
-                data[i] = new DataCellView(newC, 0, i);
-                data[i].setPreferredSize(new Dimension(cellWidth, cellHeight));
-                centerPanel.add(data[i]);
-
-                // show locked cell
-                if (tempLock) {
-                    data[i].setForeground(Color.GRAY);
-                }         
+            	DataCell newC = new DataCell(this, i);      
             }
         }
 
@@ -547,35 +158,10 @@ public abstract class Table extends JPanel implements Serializable {
 
     public abstract TableType getType();
 
-    public DataCellView getDataCell(int location) {
+    public DataCell getDataCell(int location) {
         return data[location];
     }
 
-    @Override
-    public String getName() {
-        if(null == name || name.isEmpty()) {
-            StringBuilder sb = new StringBuilder();
-            sb.append(Settings.DEFAULT_TABLE_NAME);
-
-            if(0 != this.getStorageAddress()) {
-                sb.append(" ("+this.getStorageAddress() + ")");
-            }
-
-            if(null != this.getLogParam() && !this.getLogParam().isEmpty()) {
-                sb.append(" - " + this.getLogParam());
-            }
-
-            return sb.toString();
-        }
-        return name;
-    }
-
-    @Override
-    public void setName(String name) {
-        if(null != name && !name.isEmpty()) {
-            this.name = name;
-        }
-    }
 
     public String getCategory() {
         return category;
@@ -673,7 +259,7 @@ public abstract class Table extends JPanel implements Serializable {
     }
 
     public void setDataSize(int size) {
-        data = new DataCellView[size];
+        data = new DataCell[size];
     }
 
     public int getDataSize() {
@@ -698,24 +284,21 @@ public abstract class Table extends JPanel implements Serializable {
 
     @Override
     public String toString() {
-        /*String output = "\n   ---- Table " + name + " ----" +
-                scale +
-                "\n   Category: " + category +
-                "\n   Type: " + type +
-                "\n   Description: " + description +
-                "\n   Storage Address: " + Integer.toHexString(storageAddress) +
-                "\n   Storage Type: " + storageType +
-                "\n   Endian: " + endian +
-                "\n   Flip: " + flip +
-                "\n   ---- End Table " + name + " ----";
-        for (int i = 0; i < data.length; i++) {
-            if (data[i] != null) {
-                output = output + "\nData: " + data[i];
-            }
-        }
+        if(null == name || name.isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(Settings.DEFAULT_TABLE_NAME);
 
-        return output;*/
-        return getName();
+            if(0 != this.getStorageAddress()) {
+                sb.append(" ("+this.getStorageAddress() + ")");
+            }
+
+            if(null != this.getLogParam() && !this.getLogParam().isEmpty()) {
+                sb.append(" - " + this.getLogParam());
+            }
+
+            return sb.toString();
+        }
+        return name;
     }
 
     @Override
@@ -734,15 +317,6 @@ public abstract class Table extends JPanel implements Serializable {
             }
 
             Table otherTable = (Table)other;
-
-            if( (null == this.getName() && null == otherTable.getName())
-                    || (this.getName().isEmpty() && otherTable.getName().isEmpty()) ) {
-                ;// Skip name compare if name is null or empty.
-            } else {
-                if(!this.getName().equalsIgnoreCase(otherTable.getName())) {
-                    return false;
-                }
-            }
 
             if(this.data.length != otherTable.data.length)
             {
@@ -838,14 +412,13 @@ public abstract class Table extends JPanel implements Serializable {
 
     public void calcCellRanges() {
     	if(data.length > 0) {
-	        double binMax = data[0].getDataCell().getBinValue();
-	        double binMin = data[0].getDataCell().getBinValue();
+	        double binMax = data[0].getBinValue();
+	        double binMin = data[0].getBinValue();
 	
-	        double compareMax = data[0].getDataCell().getCompareValue();
-	        double compareMin = data[0].getDataCell().getCompareValue();
+	        double compareMax = data[0].getCompareValue();
+	        double compareMin = data[0].getCompareValue();
 	
-	        for(DataCellView view : data) {
-	        	DataCell cell = view.getDataCell();
+	        for(DataCell cell : data) {
 	        	
 	            // Calc bin
 	            if(binMax < cell.getBinValue()) {
@@ -923,33 +496,13 @@ public abstract class Table extends JPanel implements Serializable {
         this.minCompare = minCompare;
     }
 
-    public void drawTable() {
-    	
-        for(DataCellView cell : data) {
-            if(null != cell) {
-                cell.drawCell();
-            }
-        }
-    }
-
-    public Dimension getFrameSize() {
-        int height = verticalOverhead + cellHeight;
-        int width = horizontalOverhead + data.length * cellWidth;
-        if (height < minHeight) {
-            height = minHeight;
-        }
-        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
-        if (width < minWidth) {
-            width = minWidth;
-        }
-        return new Dimension(width, height);
-    }
-
+    //TODO: Rework
+    //Cell should check if selected and then increment
     public void increment(double increment) {
         if (!locked && !(userLevel > getSettings().getUserLevel())) {
-            for (DataCellView cell : data) {
+            for (DataCell cell : data) {
                 if (cell.isSelected()) {
-                    cell.getDataCell().increment(increment);
+                    cell.increment(increment);
                 }
             }
         } else if (userLevel > getSettings().getUserLevel()) {
@@ -963,14 +516,14 @@ public abstract class Table extends JPanel implements Serializable {
     public void multiply(double factor) {
     	
         if (!locked && !(userLevel > getSettings().getUserLevel())) {
-            for (DataCellView cell : data) {
+            for (DataCell cell : data) {
                 if (cell.isSelected()) {
                 	
                 	//Use raw or real value, depending on view settings
                 	if(getCurrentScale().getName().equals("Raw Value"))
-                		cell.getDataCell().multiplyRaw(factor);                	
+                		cell.multiplyRaw(factor);                	
                 	else 
-                		cell.getDataCell().multiply(factor);               	
+                		cell.multiply(factor);               	
                 }
             }
         } else if (userLevel > getSettings().getUserLevel()) {
@@ -983,9 +536,9 @@ public abstract class Table extends JPanel implements Serializable {
 
     public void setRealValue(String realValue) {
         if (!locked && userLevel <= getSettings().getUserLevel()) {
-            for(DataCellView cell : data) {
+            for(DataCell cell : data) {
                 if (cell.isSelected()) {
-                    cell.getDataCell().setRealValue(realValue);
+                    cell.setRealValue(realValue);
                 }
             }
         } else if (userLevel > getSettings().getUserLevel()) {
@@ -996,95 +549,23 @@ public abstract class Table extends JPanel implements Serializable {
         }
     }
 
-    public void clearSelection() {
-        clearSelectedData();
-    }
-
-    public void clearSelectedData() {
-        for (DataCellView cell : data) {
-            if(cell.isSelected()) {
-                cell.setSelected(false);
-            }
-        }
-    }
-
-    public void startHighlight(int x, int y) {
-        this.highlightY = y;
-        this.highlightX = x;
-        highlight = true;
-        highlight(x, y);
-    }
-
-    public void highlight(int x, int y) {
-        if (highlight) {
-            for (int i = 0; i < data.length; i++) {
-                if ((i >= highlightY && i <= y) || (i <= highlightY && i >= y)) {
-                    data[i].setHighlighted(true);
-                } else {
-                    data[i].setHighlighted(false);
-                }
-            }
-        }
-    }
-
-    public void stopHighlight() {
-        highlight = false;
-        // loop through, selected and un-highlight
-        for (DataCellView cell : data) {
-            if (cell.isHighlighted()) {
-                cell.setHighlighted(false);
-                if(!cell.isSelected()) {
-                    cell.setSelected(true);
-                }
-            }
-        }
-    }
-
-    public abstract void cursorUp();
-
-    public abstract void cursorDown();
-
-    public abstract void cursorLeft();
-
-    public abstract void cursorRight();
-
-    public abstract void shiftCursorUp();
-
-    public abstract void shiftCursorDown();
-
-    public abstract void shiftCursorLeft();
-
-    public abstract void shiftCursorRight();
 
     public void setRevertPoint() {
-        for (DataCellView cell : data) {
-            cell.getDataCell().setRevertPoint();
+        for (DataCell cell : data) {
+            cell.setRevertPoint();
         }
     }
 
     public void undoAll() {
-        clearLiveDataTrace();
-        for (DataCellView cell : data) {
-            cell.getDataCell().undo();
+        for (DataCell cell : data) {
+            cell.undo();
         }
     }
-
-    public void undoSelected() {
-        clearLiveDataTrace();
-        for (DataCellView cell : data) {
-            // reset current value to original value
-            if (cell.isSelected()) {
-                cell.getDataCell().undo();
-            }
-        }
-    }
-    
+  
     abstract public byte[] saveFile(byte[] binData);
     
     public void setValues(String name, String value) {
-    	if(presetManager == null) presetManager = new PresetManager(this);
-    	if(presetPanel == null) presetPanel = new PresetPanel(this, presetManager);
-    	
+    	if(presetManager == null) presetManager = new PresetManager(this);   	
     	presetManager.setValues(name, value);
     }
     
@@ -1130,128 +611,6 @@ public abstract class Table extends JPanel implements Serializable {
 		return bitMask;
 	}
     
-    @Override
-    public void addKeyListener(KeyListener listener) {
-        super.addKeyListener(listener);
-        for (DataCellView cell : data) {
-            for (int z = 0; z < storageType; z++) {
-                cell.addKeyListener(listener);
-            }
-        }
-    }
-
-    public void selectCellAt(int y) {
-        if(y >= 0 && y < data.length) {
-            clearSelection();
-            data[y].setSelected(true);
-            highlightY = y;
-            ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(this);
-        }
-    }
-
-    public void selectCellAtWithoutClear(int y) {
-        if(y >= 0 && y < data.length) {
-            data[y].setSelected(true);
-            highlightY = y;
-            ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(this);
-        }
-    }
-
-    public void copySelection() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
-
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        }
-
-        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        copySelectionWorker = new CopySelectionWorker(this);
-        copySelectionWorker.execute();
-    }
-
-    public StringBuffer getTableAsString() {
-        StringBuffer output = new StringBuffer(Settings.BLANK);
-        for (int i = 0; i < data.length; i++) {
-            if (overlayLog) {
-                output.append(data[i].getCellText());
-            }
-            else {
-            	if(data[i]!= null)
-            		output.append(NumberUtil.stringValue(data[i].getDataCell().getRealValue()));
-            }
-            if (i < data.length - 1) {
-                output.append(Settings.TAB);
-            }
-        }
-        return output;
-    }
-
-    public void copyTable() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        }
-        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        copyTableWorker = new CopyTableWorker(this);
-        copyTableWorker.execute();
-    }
-
-    public String getCellAsString(int index) {
-        return data[index].getText();
-    }
-
-    public void pasteValues(String[] input) {
-        //set real values
-        for (int i = 0; i < input.length; i++) {
-            try {
-                Double.parseDouble(input[i]);
-                data[i].getDataCell().setRealValue(input[i]);
-            } catch (NumberFormatException ex) { /* not a number, do nothing */ }
-        }
-    }
-
-    public void paste() {
-        // TODO: This sounds like desearialize.
-        if (!staticDataTable) {
-            StringTokenizer st = new StringTokenizer(Settings.BLANK);
-            try {
-                String input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
-                st = new StringTokenizer(input, ST_DELIMITER);
-            } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
-            } catch (IOException ex) {
-            }
-    
-            String pasteType = st.nextToken();
-    
-            if ("[Table1D]".equalsIgnoreCase(pasteType)) { // copied entire table
-                int i = 0;
-                while (st.hasMoreTokens()) {
-                    String currentToken = st.nextToken();
-                    try {
-                        if (!data[i].getText().equalsIgnoreCase(currentToken)) {
-                            data[i].getDataCell().setRealValue(currentToken);
-                        }
-                    } catch (ArrayIndexOutOfBoundsException ex) { /* table larger than target, ignore*/ }
-                    i++;
-                }
-            } else if ("[Selection1D]".equalsIgnoreCase(pasteType)) { // copied selection
-                if (data[highlightY].isSelected()) {
-                    int i = 0;
-                    while (st.hasMoreTokens()) {
-                        String currentToken = st.nextToken();
-                        try {
-                            if (!data[highlightY + i].getText().equalsIgnoreCase(currentToken)) {
-                                data[highlightY + i].getDataCell().setRealValue(currentToken);
-                            }
-                        } catch (ArrayIndexOutOfBoundsException ex) { /* paste larger than target, ignore */ }
-                        i++;
-                    }
-                }
-            }
-        }
-    }
 
     public void verticalInterpolate() {
     }
@@ -1267,26 +626,21 @@ public abstract class Table extends JPanel implements Serializable {
         return (x1 == x2) ? 0.0 : (y1 + (x - x1) * (y2 - y1) / (x2 - x1));
     }
 
-    public void validateScaling() {
+    public boolean validateScaling() {
         if (getType() != TableType.SWITCH) {
 
             // make sure a scale is present
             if (scales.isEmpty()) {
                 scales.add(new Scale());
             }
-
+            
             for(Scale scale : scales) {
-                double startValue = 5;
-                double toReal = JEPUtil.evaluate(scale.getExpression(), startValue); // convert real world value of "5"
-                double endValue = JEPUtil.evaluate(scale.getByteExpression(), toReal);
-
-                // if real to byte doesn't equal 5, report conflict
-                if (Math.abs(endValue - startValue) > .001) {
+                if (!scale.validate()) {
 
                     JPanel panel = new JPanel();
                     panel.setLayout(new GridLayout(4, 1));
                     panel.add(new JLabel(MessageFormat.format(
-                            rb.getString("REALBYTEINVALID"), getName())));
+                            rb.getString("REALBYTEINVALID"), toString())));
                     panel.add(new JLabel(MessageFormat.format(
                             rb.getString("REALVALUE"), scale.getExpression())));
                     panel.add(new JLabel(MessageFormat.format(
@@ -1295,7 +649,8 @@ public abstract class Table extends JPanel implements Serializable {
                     JCheckBox check = new JCheckBox(rb.getString("DISPLAYMSG"), true);
                     check.setHorizontalAlignment(JCheckBox.RIGHT);
                     panel.add(check);
-
+                    
+                    
                     check.addActionListener(
                             new ActionListener() {
                                 @Override
@@ -1317,35 +672,23 @@ public abstract class Table extends JPanel implements Serializable {
             return;
         }
 
-        DataCellView[] compareData = otherTable.getData();
+        DataCell[] compareData = otherTable.getData();
         if(data.length != compareData.length) {
             return;
         }
 
-        clearLiveDataTrace();
 
         int i = 0;
-        for(DataCellView cell : data) {
-            cell.getDataCell().setCompareValue(compareData[i].getDataCell());
+        for(DataCell cell : data) {
+            cell.setCompareValue(compareData[i]);
             i++;
         }
 
         calcCellRanges();
-        drawTable();
-    }
-
-    public void setCompareDisplay(Settings.CompareDisplay compareDisplay) {
-        this.compareDisplay = compareDisplay;
-        drawTable();
-    }
-
-    public Settings.CompareDisplay getCompareDisplay() {
-        return this.compareDisplay;
     }
 
     public void setCompareValueType(Settings.DataType compareValueType) {
         this.compareValueType = compareValueType;
-        drawTable();
     }
 
     public Settings.DataType getCompareValueType() {
@@ -1381,18 +724,11 @@ public abstract class Table extends JPanel implements Serializable {
 
     public void setCurrentScale(Scale curScale) {
         this.curScale = curScale;
-        updateTableLabel();
-        drawTable();
     }
 
     public Settings getSettings()
     {
         return SettingsManager.getSettings();
-    }
-
-    public TableToolBar getToolbar()
-    {
-        return ECUEditorManager.getECUEditor().getTableToolBar();
     }
 
     public boolean isLocked() {
@@ -1403,14 +739,7 @@ public abstract class Table extends JPanel implements Serializable {
         this.locked = locked;
     }
 
-    public void setOverlayLog(boolean overlayLog) {
-        this.overlayLog = overlayLog;
-    }
 
-    public boolean getOverlayLog()
-    {
-        return this.overlayLog;
-    }
 
     public double getLiveAxisValue() {
         try {
@@ -1424,44 +753,6 @@ public abstract class Table extends JPanel implements Serializable {
 
     public abstract boolean isButtonSelected();
 
-    public void highlightLiveData(String liveVal) {
-        if (getOverlayLog()) {
-            double liveValue = 0.0;
-            try {
-            	liveValue = NumberUtil.doubleValue(liveVal);
-            } catch (Exception ex) {
-            	LOGGER.error("Table - live data highlight parsing error for value: " + liveVal);
-            	return;
-            }
-
-            int startIdx = data.length;
-            for (int i = 0; i < data.length; i++) {
-                double currentValue = data[i].getDataCell().getRealValue();
-                if (liveValue == currentValue) {
-                    startIdx = i;
-                    break;
-                } else if (liveValue < currentValue){
-                    startIdx = i-1;
-                    break;
-                }
-            }
-
-            setLiveDataIndex(startIdx);
-            DataCellView cell = data[getLiveDataIndex()];
-            cell.setPreviousLiveDataTrace(false);
-            cell.setLiveDataTrace(true);
-            cell.getDataCell().setLiveDataTraceValue(liveVal);
-            getToolbar().setLiveDataValue(liveVal);
-        }
-    }
-
-    public void updateLiveDataHighlight() {
-        if (getOverlayLog()) {
-            data[getPreviousLiveDataIndex()].setPreviousLiveDataTrace(true);
-            data[getLiveDataIndex()].setPreviousLiveDataTrace(false);
-            data[getLiveDataIndex()].setLiveDataTrace(true);
-        }
-    }
 
     public int getLiveDataIndex() {
         return liveDataIndex;
@@ -1482,17 +773,6 @@ public abstract class Table extends JPanel implements Serializable {
         this.liveDataIndex = index;
     }
 
-    public void clearLiveDataTrace() {
-        for (DataCellView cell : data) {
-            cell.setLiveDataTrace(false);
-            cell.setPreviousLiveDataTrace(false);
-        }
-    }
-
-    public String getLogParamString() {
-        return getName()+ ":" + getLogParam();
-    }
-
     public Table getCompareTable() {
         return compareTable;
     }
@@ -1501,20 +781,9 @@ public abstract class Table extends JPanel implements Serializable {
         this.compareTable = compareTable;
     }
 
-    public void updateTableLabel() {
-        if(null == name || name.isEmpty()) {
-            ;// Do not update label.
-        } else if(null == getCurrentScale () || "0x" == getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            tableLabel.setText(getName());
-        } else {
-            tableLabel.setText(getName() + " (" + getCurrentScale().getUnit() + ")");
-        }
-    }
 
     public void colorCells() {
         calcCellRanges();
-        drawTable();
     }
 
     public void refreshCompare() {
@@ -1568,88 +837,7 @@ public abstract class Table extends JPanel implements Serializable {
             return String.valueOf(marshallingCode);
         }
     }
-}
 
-class CopySelectionWorker extends SwingWorker<Void, Void> {
-    Table table;
 
-    public CopySelectionWorker(Table table) {
-        this.table = table;
-    }
 
-    @Override
-    protected Void doInBackground() throws Exception {
-        // find bounds of selection
-        // coords[0] = x min, y min, x max, y max
-        String output = "[Selection1D]" + Settings.NEW_LINE;
-        boolean copy = false;
-        int[] coords = new int[2];
-        coords[0] = table.getDataSize();
-
-        for (int i = 0; i < table.getDataSize(); i++) {
-            if (table.getData()[i].isSelected()) {
-                if (i < coords[0]) {
-                    coords[0] = i;
-                    copy = true;
-                }
-                if (i > coords[1]) {
-                    coords[1] = i;
-                    copy = true;
-                }
-            }
-        }
-        //make a string of the selection
-        for (int i = coords[0]; i <= coords[1]; i++) {
-            if (table.getData()[i].isSelected()) {
-                output = output + NumberUtil.stringValue(table.getData()[i].getDataCell().getRealValue());
-            } else {
-                output = output + "x"; // x represents non-selected cell
-            }
-            if (i < coords[1]) {
-                output = output + "\t";
-            }
-        }
-        //copy to clipboard
-        if (copy) {
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(output), null);
-        }
-        return null;
-    }
-
-    @Override
-    public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(null);
-        }
-        table.setCursor(null);
-        ECUEditorManager.getECUEditor().setCursor(null);
-    }
-}
-
-class CopyTableWorker extends SwingWorker<Void, Void> {
-    Table table;
-
-    public CopyTableWorker(Table table) {
-        this.table = table;
-    }
-
-    @Override
-    protected Void doInBackground() throws Exception {
-        String tableHeader = table.getSettings().getTableHeader();
-        StringBuffer output = new StringBuffer(tableHeader);
-        output.append(table.getTableAsString());
-        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
-        return null;
-    }
-
-    @Override
-    public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(null);
-        }
-        table.setCursor(null);
-        ECUEditorManager.getECUEditor().setCursor(null);
-    }
 }

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -27,8 +27,10 @@ import javax.naming.NameNotFoundException;
 import org.apache.log4j.Logger;
 
 import com.romraider.Settings;
+import com.romraider.swing.TableFrame;
 import com.romraider.util.ByteUtil;
 import com.romraider.util.JEPUtil;
+import com.romraider.util.NumberUtil;
 import com.romraider.util.SettingsManager;
 
 public abstract class Table implements Serializable {
@@ -38,6 +40,7 @@ public abstract class Table implements Serializable {
     protected static Settings.Endian memModelEndian;
 
     protected TableView tableView;
+    protected TableFrame tableFrame;
     
     protected String name;
     protected String category = "Other";
@@ -93,6 +96,14 @@ public abstract class Table implements Serializable {
     	return this.tableView;
     }
     
+    public void setTableFrame(TableFrame v) {
+    	this.tableFrame = v;
+    }
+    
+    public TableFrame getTableFrame() {
+    	return this.tableFrame;
+    }
+    
     public DataCell[] getData() {
         return data;
     }
@@ -100,6 +111,7 @@ public abstract class Table implements Serializable {
     public void setData(DataCell[] data) {
         this.data = data;
     }
+    
     
     public int getRamOffset() {
     	return this.ramOffset;
@@ -273,8 +285,26 @@ public abstract class Table implements Serializable {
         return name;
     }
     
+    public void setName(String n) {
+    	this.name = n;
+    }
+    
     public String getName() {
     	return toString();
+    }
+    
+    public StringBuffer getTableAsString() {
+        StringBuffer output = new StringBuffer(Settings.BLANK);
+        for (int i = 0; i < data.length; i++) {
+
+            if(data[i]!= null)
+            	output.append(NumberUtil.stringValue(data[i].getRealValue()));
+
+            if (i < data.length - 1) {
+                output.append(Settings.TAB);
+            }
+        }
+        return output;
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table1D.java
+++ b/src/main/java/com/romraider/maps/Table1D.java
@@ -43,6 +43,13 @@ public class Table1D extends Table {
         return axisParent;
     }
     
+    @Override
+    public void setCurrentScale(Scale curScale) {
+        this.curScale = curScale;
+        
+        if(tableView!=null) tableView.drawTable();
+    }
+  
 	@Override
 	public byte[] saveFile(byte[] binData) {
 		return binData;

--- a/src/main/java/com/romraider/maps/Table1D.java
+++ b/src/main/java/com/romraider/maps/Table1D.java
@@ -80,34 +80,11 @@ public class Table1D extends Table {
       
         }
     }
-        
+    
     @Override
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
-        super.populateTable(input, romRamOffset);
-        /*
-    	centerLayout.setRows(1);
-        centerLayout.setColumns(this.getDataSize());
-
-        // add to table
-        for (int i = 0; i < this.getDataSize(); i++) {
-            centerPanel.add(this.getDataCell(i));
-        }
-
-        if(null == name || name.isEmpty()) {
-            ;// Do not add label.
-        } else if(null == getCurrentScale () || "0x" == getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            tableLabel = new JLabel(getName(), JLabel.CENTER);
-            add(tableLabel, BorderLayout.NORTH);
-        } else {
-            tableLabel = new JLabel(getName() + " (" + getCurrentScale().getUnit() + ")", JLabel.CENTER);
-            add(tableLabel, BorderLayout.NORTH);
-        }
-        
-        if(tableLabel != null)
-        	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));
-        
-        if(presetPanel != null) presetPanel.populatePanel();*/
+    public void clearData() {
+    	super.clearData();
+    	axisParent = null;
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table1D.java
+++ b/src/main/java/com/romraider/maps/Table1D.java
@@ -18,7 +18,6 @@
  */
 
 package com.romraider.maps;
-
 import com.romraider.Settings;
 
 public class Table1D extends Table {
@@ -55,10 +54,12 @@ public class Table1D extends Table {
 		return binData;
 	}
 	
-    public void addStaticDataCell(DataCell input) {
+    public void addStaticDataCell(String s) {
+    	DataCell c = new DataCell(this, s, null);
+    	
         for(int i = 0; i < data.length; i++) {
             if(data[i] == null) {
-                data[i] = input;
+                data[i] = c;
                 break;
             }
         }

--- a/src/main/java/com/romraider/maps/Table1D.java
+++ b/src/main/java/com/romraider/maps/Table1D.java
@@ -129,7 +129,7 @@ public class Table1D extends Table {
         return getType() == Table.TableType.X_AXIS ||
                 getType() == Table.TableType.Y_AXIS || isStaticDataTable();
     }
-
+      
     @Override
     public boolean equals(Object other) {
         try {

--- a/src/main/java/com/romraider/maps/Table1D.java
+++ b/src/main/java/com/romraider/maps/Table1D.java
@@ -19,19 +19,11 @@
 
 package com.romraider.maps;
 
-import java.awt.BorderLayout;
-
-import javax.swing.JLabel;
-import javax.swing.border.EmptyBorder;
-
-import com.romraider.Settings;
-import com.romraider.util.NumberUtil;
-
 public class Table1D extends Table {
     private static final long serialVersionUID = -8747180767803835631L;
     private Table axisParent = null;
     private final TableType type;
-
+    
     public Table1D(TableType type) {
         this.type = type;
     }
@@ -48,16 +40,6 @@ public class Table1D extends Table {
     public Table getAxisParent() {
         return axisParent;
     }
-
-    public void addStaticDataCell(DataCellView input) {
-        for(int i = 0; i < data.length; i++) {
-            if(data[i] == null) {
-                data[i] = input;
-                data[i].setY(i);
-                break;
-            }
-        }
-    }
     
 	@Override
 	public byte[] saveFile(byte[] binData) {
@@ -66,10 +48,10 @@ public class Table1D extends Table {
 	
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
-        centerLayout.setRows(1);
-        centerLayout.setColumns(this.getDataSize());
-
         super.populateTable(input, romRamOffset);
+        /*
+    	centerLayout.setRows(1);
+        centerLayout.setColumns(this.getDataSize());
 
         // add to table
         for (int i = 0; i < this.getDataSize(); i++) {
@@ -90,235 +72,12 @@ public class Table1D extends Table {
         if(tableLabel != null)
         	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));
         
-        if(presetPanel != null) presetPanel.populatePanel();
+        if(presetPanel != null) presetPanel.populatePanel();*/
     }
 
     @Override
     public String toString() {
         return super.toString() + " (1D)";
-    }
-
-    @Override
-    public void cursorUp() {
-        if (type == Table.TableType.Y_AXIS) {
-            if (highlightY > 0 && data[highlightY].isSelected()) {
-                selectCellAt(highlightY - 1);
-            }
-        } else if (type == Table.TableType.X_AXIS) {
-            // Y axis is on top.. nothing happens
-        } else if (type == Table.TableType.TABLE_1D) {
-            // no where to move up to
-        }
-    }
-
-    @Override
-    public void cursorDown() {
-        if (type == Table.TableType.Y_AXIS) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                if (highlightY < getDataSize() - 1 && data[highlightY].isSelected()) {
-                    selectCellAt(highlightY + 1);
-                }
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                if (data[highlightY].isSelected()) {
-                    getAxisParent().selectCellAt(highlightY);
-                }
-            }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-        } else if (type == Table.TableType.TABLE_1D) {
-            // no where to move down to
-        }
-    }
-
-    @Override
-    public void cursorLeft() {
-        if (type == Table.TableType.Y_AXIS) {
-            // X axis is on left.. nothing happens
-            if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                if (data[highlightY].isSelected()) {
-                    selectCellAt(highlightY - 1);
-                }
-            }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            if (highlightY > 0) {
-                selectCellAt(highlightY - 1);
-            }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
-            if (highlightY > 0) {
-                selectCellAt(highlightY - 1);
-            }
-        }
-    }
-
-    @Override
-    public void cursorRight() {
-        if (type == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                selectCellAt(highlightY + 1);
-            }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
-                selectCellAt(highlightY + 1);
-            }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
-                selectCellAt(highlightY + 1);
-            }
-        }
-    }
-
-	@Override
-	public void shiftCursorUp() {
-        if (type == Table.TableType.Y_AXIS) {
-            if (highlightY > 0 && data[highlightY].isSelected()) {
-            	selectCellAtWithoutClear(highlightY - 1);
-            }
-        } else if (type == Table.TableType.X_AXIS) {
-            // Y axis is on top.. nothing happens
-        } else if (type == Table.TableType.TABLE_1D) {
-            // no where to move up to
-        }
-	}
-
-	@Override
-	public void shiftCursorDown() {
-        if (type == Table.TableType.Y_AXIS) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                if (highlightY < getDataSize() - 1 && data[highlightY].isSelected()) {
-                	selectCellAtWithoutClear(highlightY + 1);
-                }
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                if (data[highlightY].isSelected()) {
-                    getAxisParent().selectCellAtWithoutClear(highlightY);
-                }
-            }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-        } else if (type == Table.TableType.TABLE_1D) {
-            // no where to move down to
-        }
-	}
-
-	@Override
-	public void shiftCursorLeft() {
-        if (type == Table.TableType.Y_AXIS) {
-            // X axis is on left.. nothing happens
-            if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                if (data[highlightY].isSelected()) {
-                	selectCellAtWithoutClear(highlightY - 1);
-                }
-            }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            if (highlightY > 0) {
-            	selectCellAtWithoutClear(highlightY - 1);
-            }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
-            if (highlightY > 0) {
-            	selectCellAtWithoutClear(highlightY - 1);
-            }
-        }
-	}
-
-	@Override
-	public void shiftCursorRight() {
-        if (type == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
-            	selectCellAtWithoutClear(highlightY + 1);
-            }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
-            	selectCellAtWithoutClear(highlightY + 1);
-            }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
-            	selectCellAtWithoutClear(highlightY + 1);
-            }
-        }
-	}
-
-    @Override
-    public void clearSelection() {
-        // Call to the axis parent.  The axis parent should then call to clear this data.
-    	Table p = getAxisParent();
-    	
-    	if(p != null)
-    		p.clearSelection();
-    }
-
-    @Override
-    public void startHighlight(int x, int y) {
-        Table axisParent = getAxisParent();
-        
-        if(axisParent != null)
-        	axisParent.clearSelectedData();
-
-        if(axisParent instanceof Table3D) {
-            Table3D table3D = (Table3D) axisParent;
-            if(getType() == Table.TableType.X_AXIS) {
-                table3D.getYAxis().clearSelectedData();
-            } else if (getType() == Table.TableType.Y_AXIS) {
-                table3D.getXAxis().clearSelectedData();
-            }
-        } else if (axisParent instanceof Table2D) {
-            ((Table2D) axisParent).getAxis().clearSelectedData();
-        }
-
-
-        super.startHighlight(x, y);
-    }
-
-    @Override
-    public String getCellAsString(int index) {
-        return data[index].getText();
-    }
-
-    @Override
-    public void highlightLiveData(String liveVal) {
-        if (getOverlayLog()) {
-            double liveValue = 0.0;
-            try {
-                liveValue = NumberUtil.doubleValue(liveVal);
-            } catch (Exception ex) {
-            	LOGGER.error("Table1D - live data highlight parsing error for value: " + liveVal);
-                return;
-            }
-
-            int startIdx = data.length;
-            for (int i = 0; i < data.length; i++) {
-                double currentValue = 0.0;
-                if(isStaticDataTable() && null != data[i].getStaticText()) {
-                    try {
-                        currentValue = Double.parseDouble(data[i].getStaticText());
-                    } catch(NumberFormatException nex) {
-                        return;
-                    }
-                } else {
-                    currentValue = data[i].getDataCell().getRealValue();
-                }
-
-                if (liveValue == currentValue) {
-                    startIdx = i;
-                    break;
-                } else if (liveValue < currentValue){
-                    startIdx = i-1;
-                    break;
-                }
-            }
-
-            setLiveDataIndex(startIdx);
-            DataCellView cellp = data[getPreviousLiveDataIndex()];
-            cellp.setPreviousLiveDataTrace(true);
-            DataCellView cell = data[getLiveDataIndex()];
-            cell.setPreviousLiveDataTrace(false);
-            cell.setLiveDataTrace(true);
-            cell.getDataCell().setLiveDataTraceValue(liveVal);
-            getToolbar().setLiveDataValue(liveVal);
-        }
-        getAxisParent().updateLiveDataHighlight();
     }
 
     @Override
@@ -378,27 +137,6 @@ public class Table1D extends Table {
         } catch(Exception ex) {
             // TODO: Log Exception.
             return false;
-        }
-    }
-
-    @Override
-    public void updateTableLabel() {
-        this.getAxisParent().updateTableLabel();
-    }
-
-    @Override
-    public StringBuffer getTableAsString() {
-        if(isStaticDataTable()) {
-            StringBuffer output = new StringBuffer(Settings.BLANK);
-            for (int i = 0; i < data.length; i++) {
-                output.append(data[i].getStaticText());
-                if (i < data.length - 1) {
-                    output.append(Settings.TAB);
-                }
-            }
-            return output;
-        } else {
-            return super.getTableAsString();
         }
     }
 }

--- a/src/main/java/com/romraider/maps/Table1D.java
+++ b/src/main/java/com/romraider/maps/Table1D.java
@@ -19,6 +19,8 @@
 
 package com.romraider.maps;
 
+import com.romraider.Settings;
+
 public class Table1D extends Table {
     private static final long serialVersionUID = -8747180767803835631L;
     private Table axisParent = null;
@@ -46,6 +48,32 @@ public class Table1D extends Table {
 		return binData;
 	}
 	
+    public void addStaticDataCell(DataCell input) {
+        for(int i = 0; i < data.length; i++) {
+            if(data[i] == null) {
+                data[i] = input;
+                break;
+            }
+        }
+    }
+    
+    @Override
+    public StringBuffer getTableAsString() {
+        if(isStaticDataTable()) {
+            StringBuffer output = new StringBuffer(Settings.BLANK);
+            for (int i = 0; i < data.length; i++) {
+                output.append(data[i].getStaticText());
+                if (i < data.length - 1) {
+                    output.append(Settings.TAB);
+                }
+            }
+            return output;
+        } else {
+            return super.getTableAsString();
+      
+        }
+    }
+        
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
         super.populateTable(input, romRamOffset);
@@ -140,3 +168,5 @@ public class Table1D extends Table {
         }
     }
 }
+
+    

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -24,6 +24,7 @@ import java.awt.BorderLayout;
 import javax.swing.JLabel;
 import javax.swing.border.EmptyBorder;
 
+import com.romraider.maps.Table.TableType;
 import com.romraider.util.NumberUtil;
 
 public class Table1DView extends TableView {
@@ -34,6 +35,7 @@ public class Table1DView extends TableView {
     public Table1DView(Table1D table) {
 		super(table);
     	this.table = table;
+    	
     	populateTableVisual();
 	}
     
@@ -48,36 +50,40 @@ public class Table1DView extends TableView {
     }
     
     @Override
-    public void populateTableVisual()   {
-        centerLayout.setRows(1);
-        centerLayout.setColumns(table.getDataSize());
+    public void populateTableVisual() {
         super.populateTableVisual();
-
-        // add to table
-        for (int i = 0; i < table.getDataSize(); i++) {
-            centerPanel.add(this.getDataCell(i));
-        }
-
-        if(null == table.name || table.name.isEmpty()) {
-            ;// Do not add label.
-        } else if(null == table.getCurrentScale () || "0x" == table.getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            tableLabel = new JLabel(getName(), JLabel.CENTER);
-            add(tableLabel, BorderLayout.NORTH);
-        } else {
-            tableLabel = new JLabel(getName() + " (" + table.getCurrentScale().getUnit() + ")", JLabel.CENTER);
-            add(tableLabel, BorderLayout.NORTH);
-        }
         
-        if(tableLabel != null)
-        	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));
-        
-        if(presetPanel != null) presetPanel.populatePanel();
+        //Only populate the rest if we aren't an axis
+    	if(table.getType() == TableType.TABLE_1D) {
+	        centerLayout.setRows(1);
+	        centerLayout.setColumns(table.getDataSize());
+
+	        // add to table
+	        for (int i = 0; i < table.getDataSize(); i++) {
+	            centerPanel.add(this.getDataCell(i));
+	        }
+	
+	        if(null == table.name || table.name.isEmpty()) {
+	            ;// Do not add label.
+	        } else if(null == table.getCurrentScale () || "0x" == table.getCurrentScale().getUnit()) {
+	            // static or no scale exists.
+	            tableLabel = new JLabel(getName(), JLabel.CENTER);
+	            add(tableLabel, BorderLayout.NORTH);
+	        } else {
+	            tableLabel = new JLabel(getName() + " (" + table.getCurrentScale().getUnit() + ")", JLabel.CENTER);
+	            add(tableLabel, BorderLayout.NORTH);
+	        }
+	        
+	        if(tableLabel != null)
+	        	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));
+	        
+	        if(presetPanel != null) presetPanel.populatePanel();
+    	}
     }
 
     @Override
     public String toString() {
-        return super.toString() + " (1D)";
+        return table.toString() + " View";
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -27,28 +27,16 @@ import javax.swing.border.EmptyBorder;
 import com.romraider.Settings;
 import com.romraider.util.NumberUtil;
 
-public class Table1D extends Table {
-    private static final long serialVersionUID = -8747180767803835631L;
-    private Table axisParent = null;
-    private final TableType type;
+public class Table1DView extends TableView {
 
-    public Table1D(TableType type) {
-        this.type = type;
-    }
+	private static final long serialVersionUID = -8747180767803835631L;
+	private Table1D table;
 
-    @Override
-    public TableType getType() {
-        return type;
-    }
-
-    public void setAxisParent(Table axisParent) {
-        this.axisParent = axisParent;
-    }
-
-    public Table getAxisParent() {
-        return axisParent;
-    }
-
+    protected Table1DView(Table1D table) {
+		super(table);
+    	this.table = table;
+	}
+    
     public void addStaticDataCell(DataCellView input) {
         for(int i = 0; i < data.length; i++) {
             if(data[i] == null) {
@@ -67,23 +55,22 @@ public class Table1D extends Table {
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
         centerLayout.setRows(1);
-        centerLayout.setColumns(this.getDataSize());
+        centerLayout.setColumns(table.getDataSize());
 
-        super.populateTable(input, romRamOffset);
 
         // add to table
-        for (int i = 0; i < this.getDataSize(); i++) {
+        for (int i = 0; i < table.getDataSize(); i++) {
             centerPanel.add(this.getDataCell(i));
         }
 
-        if(null == name || name.isEmpty()) {
+        if(null == table.name || table.name.isEmpty()) {
             ;// Do not add label.
-        } else if(null == getCurrentScale () || "0x" == getCurrentScale().getUnit()) {
+        } else if(null == table.getCurrentScale () || "0x" == table.getCurrentScale().getUnit()) {
             // static or no scale exists.
             tableLabel = new JLabel(getName(), JLabel.CENTER);
             add(tableLabel, BorderLayout.NORTH);
         } else {
-            tableLabel = new JLabel(getName() + " (" + getCurrentScale().getUnit() + ")", JLabel.CENTER);
+            tableLabel = new JLabel(getName() + " (" + table.getCurrentScale().getUnit() + ")", JLabel.CENTER);
             add(tableLabel, BorderLayout.NORTH);
         }
         
@@ -100,50 +87,50 @@ public class Table1D extends Table {
 
     @Override
     public void cursorUp() {
-        if (type == Table.TableType.Y_AXIS) {
-            if (highlightY > 0 && data[highlightY].isSelected()) {
+        if (table.getType() == Table.TableType.Y_AXIS) {
+            if (highlightY > 0 && data[highlightY].getDataCell().isSelected()) {
                 selectCellAt(highlightY - 1);
             }
-        } else if (type == Table.TableType.X_AXIS) {
+        } else if (table.getType() == Table.TableType.X_AXIS) {
             // Y axis is on top.. nothing happens
-        } else if (type == Table.TableType.TABLE_1D) {
+        } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move up to
         }
     }
 
     @Override
     public void cursorDown() {
-        if (type == Table.TableType.Y_AXIS) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                if (highlightY < getDataSize() - 1 && data[highlightY].isSelected()) {
+        if (table.getType() == Table.TableType.Y_AXIS) {
+            if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                if (highlightY < table.getDataSize() - 1 && data[highlightY].getDataCell().isSelected()) {
                     selectCellAt(highlightY + 1);
                 }
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                if (data[highlightY].isSelected()) {
-                    getAxisParent().selectCellAt(highlightY);
+            } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
+                if (data[highlightY].getDataCell().isSelected()) {
+                	selectCellAt(highlightY);
                 }
             }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-        } else if (type == Table.TableType.TABLE_1D) {
+        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].getDataCell().isSelected()) {
+            ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+        } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move down to
         }
     }
 
     @Override
     public void cursorLeft() {
-        if (type == Table.TableType.Y_AXIS) {
+        if (table.getType() == Table.TableType.Y_AXIS) {
             // X axis is on left.. nothing happens
-            if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+            if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
                     selectCellAt(highlightY - 1);
                 }
             }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
             if (highlightY > 0) {
                 selectCellAt(highlightY - 1);
             }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+        } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
             if (highlightY > 0) {
                 selectCellAt(highlightY - 1);
             }
@@ -152,18 +139,18 @@ public class Table1D extends Table {
 
     @Override
     public void cursorRight() {
-        if (type == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+        if (table.getType() == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
+            if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+            } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 selectCellAt(highlightY + 1);
             }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
+        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            if (highlightY < table.getDataSize() - 1) {
                 selectCellAt(highlightY + 1);
             }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
+        } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+            if (highlightY < table.getDataSize() - 1) {
                 selectCellAt(highlightY + 1);
             }
         }
@@ -171,50 +158,50 @@ public class Table1D extends Table {
 
 	@Override
 	public void shiftCursorUp() {
-        if (type == Table.TableType.Y_AXIS) {
+        if (table.getType() == Table.TableType.Y_AXIS) {
             if (highlightY > 0 && data[highlightY].isSelected()) {
             	selectCellAtWithoutClear(highlightY - 1);
             }
-        } else if (type == Table.TableType.X_AXIS) {
+        } else if (table.getType() == Table.TableType.X_AXIS) {
             // Y axis is on top.. nothing happens
-        } else if (type == Table.TableType.TABLE_1D) {
+        } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move up to
         }
 	}
 
 	@Override
 	public void shiftCursorDown() {
-        if (type == Table.TableType.Y_AXIS) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                if (highlightY < getDataSize() - 1 && data[highlightY].isSelected()) {
+        if (table.getType() == Table.TableType.Y_AXIS) {
+            if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                if (highlightY < table.getDataSize() - 1 && data[highlightY].isSelected()) {
                 	selectCellAtWithoutClear(highlightY + 1);
                 }
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+            } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
-                    getAxisParent().selectCellAtWithoutClear(highlightY);
+                    table.getAxisParent().selectCellAtWithoutClear(highlightY);
                 }
             }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-        } else if (type == Table.TableType.TABLE_1D) {
+        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+        } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move down to
         }
 	}
 
 	@Override
 	public void shiftCursorLeft() {
-        if (type == Table.TableType.Y_AXIS) {
+        if (table.getType() == Table.TableType.Y_AXIS) {
             // X axis is on left.. nothing happens
-            if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+            if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
                 	selectCellAtWithoutClear(highlightY - 1);
                 }
             }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
             if (highlightY > 0) {
             	selectCellAtWithoutClear(highlightY - 1);
             }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+        } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
             if (highlightY > 0) {
             	selectCellAtWithoutClear(highlightY - 1);
             }
@@ -223,18 +210,18 @@ public class Table1D extends Table {
 
 	@Override
 	public void shiftCursorRight() {
-        if (type == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
-            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
-            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+        if (table.getType() == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
+            if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+            } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
             	selectCellAtWithoutClear(highlightY + 1);
             }
-        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
+        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            if (highlightY < table.getDataSize() - 1) {
             	selectCellAtWithoutClear(highlightY + 1);
             }
-        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
-            if (highlightY < getDataSize() - 1) {
+        } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+            if (highlightY < table.getDataSize() - 1) {
             	selectCellAtWithoutClear(highlightY + 1);
             }
         }
@@ -243,7 +230,7 @@ public class Table1D extends Table {
     @Override
     public void clearSelection() {
         // Call to the axis parent.  The axis parent should then call to clear this data.
-    	Table p = getAxisParent();
+    	Table p = table.getAxisParent();
     	
     	if(p != null)
     		p.clearSelection();
@@ -251,16 +238,16 @@ public class Table1D extends Table {
 
     @Override
     public void startHighlight(int x, int y) {
-        Table axisParent = getAxisParent();
+        Table axisParent = table.getAxisParent();
         
         if(axisParent != null)
         	axisParent.clearSelectedData();
 
         if(axisParent instanceof Table3D) {
             Table3D table3D = (Table3D) axisParent;
-            if(getType() == Table.TableType.X_AXIS) {
+            if(table.getType() == Table.TableType.X_AXIS) {
                 table3D.getYAxis().clearSelectedData();
-            } else if (getType() == Table.TableType.Y_AXIS) {
+            } else if (table.getType() == Table.TableType.Y_AXIS) {
                 table3D.getXAxis().clearSelectedData();
             }
         } else if (axisParent instanceof Table2D) {
@@ -290,7 +277,7 @@ public class Table1D extends Table {
             int startIdx = data.length;
             for (int i = 0; i < data.length; i++) {
                 double currentValue = 0.0;
-                if(isStaticDataTable() && null != data[i].getStaticText()) {
+                if(table.isStaticDataTable() && null != data[i].getStaticText()) {
                     try {
                         currentValue = Double.parseDouble(data[i].getStaticText());
                     } catch(NumberFormatException nex) {
@@ -318,22 +305,12 @@ public class Table1D extends Table {
             cell.getDataCell().setLiveDataTraceValue(liveVal);
             getToolbar().setLiveDataValue(liveVal);
         }
-        getAxisParent().updateLiveDataHighlight();
-    }
-
-    @Override
-    public boolean isLiveDataSupported() {
-        return false;
-    }
-
-    @Override
-    public boolean isButtonSelected() {
-        return true;
+        table.getAxisParent().updateLiveDataHighlight();
     }
 
     public boolean isAxis() {
-        return getType() == Table.TableType.X_AXIS ||
-                getType() == Table.TableType.Y_AXIS || isStaticDataTable();
+        return table.getType() == Table.TableType.X_AXIS ||
+                table.getType() == Table.TableType.Y_AXIS || table.isStaticDataTable();
     }
 
     @Override
@@ -383,12 +360,12 @@ public class Table1D extends Table {
 
     @Override
     public void updateTableLabel() {
-        this.getAxisParent().updateTableLabel();
+        this.table.getAxisParent().updateTableLabel();
     }
 
     @Override
     public StringBuffer getTableAsString() {
-        if(isStaticDataTable()) {
+        if(table.isStaticDataTable()) {
             StringBuffer output = new StringBuffer(Settings.BLANK);
             for (int i = 0; i < data.length; i++) {
                 output.append(data[i].getStaticText());

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -31,7 +31,7 @@ public class Table1DView extends TableView {
 
 	private static final long serialVersionUID = -8747180767803835631L;
 	private Table1D table;
-
+	
     protected Table1DView(Table1D table) {
 		super(table);
     	this.table = table;
@@ -47,10 +47,6 @@ public class Table1DView extends TableView {
         }
     }
     
-	@Override
-	public byte[] saveFile(byte[] binData) {
-		return binData;
-	}
 	
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
@@ -88,7 +84,7 @@ public class Table1DView extends TableView {
     @Override
     public void cursorUp() {
         if (table.getType() == Table.TableType.Y_AXIS) {
-            if (highlightY > 0 && data[highlightY].getDataCell().isSelected()) {
+            if (highlightY > 0 && data[highlightY].isSelected()) {
                 selectCellAt(highlightY - 1);
             }
         } else if (table.getType() == Table.TableType.X_AXIS) {
@@ -102,16 +98,16 @@ public class Table1DView extends TableView {
     public void cursorDown() {
         if (table.getType() == Table.TableType.Y_AXIS) {
             if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                if (highlightY < table.getDataSize() - 1 && data[highlightY].getDataCell().isSelected()) {
+                if (highlightY < table.getDataSize() - 1 && data[highlightY].isSelected()) {
                     selectCellAt(highlightY + 1);
                 }
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                if (data[highlightY].getDataCell().isSelected()) {
+                if (data[highlightY].isSelected()) {
                 	selectCellAt(highlightY);
                 }
             }
-        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].getDataCell().isSelected()) {
-            ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+        } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
         } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move down to
         }
@@ -141,7 +137,7 @@ public class Table1DView extends TableView {
     public void cursorRight() {
         if (table.getType() == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
             if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+                ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 selectCellAt(highlightY + 1);
             }
@@ -178,11 +174,11 @@ public class Table1DView extends TableView {
                 }
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
-                    table.getAxisParent().selectCellAtWithoutClear(highlightY);
+                    table.getAxisParent().getTableView().selectCellAtWithoutClear(highlightY);
                 }
             }
         } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+            ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
         } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move down to
         }
@@ -212,7 +208,7 @@ public class Table1DView extends TableView {
 	public void shiftCursorRight() {
         if (table.getType() == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
             if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) table.getAxisParent()).selectCellAt(highlightY, this);
+                ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
             	selectCellAtWithoutClear(highlightY + 1);
             }
@@ -229,11 +225,11 @@ public class Table1DView extends TableView {
 
     @Override
     public void clearSelection() {
-        // Call to the axis parent.  The axis parent should then call to clear this data.
+        // Call to the axis parent. The axis parent should then call to clear this data.
     	Table p = table.getAxisParent();
     	
     	if(p != null)
-    		p.clearSelection();
+    		p.getTableView().clearSelection();
     }
 
     @Override
@@ -241,17 +237,17 @@ public class Table1DView extends TableView {
         Table axisParent = table.getAxisParent();
         
         if(axisParent != null)
-        	axisParent.clearSelectedData();
+        	axisParent.getTableView().clearSelection();
 
         if(axisParent instanceof Table3D) {
             Table3D table3D = (Table3D) axisParent;
             if(table.getType() == Table.TableType.X_AXIS) {
-                table3D.getYAxis().clearSelectedData();
+                table3D.getYAxis().getTableView().clearSelection();
             } else if (table.getType() == Table.TableType.Y_AXIS) {
-                table3D.getXAxis().clearSelectedData();
+                table3D.getXAxis().getTableView().clearSelection();
             }
         } else if (axisParent instanceof Table2D) {
-            ((Table2D) axisParent).getAxis().clearSelectedData();
+            ((Table2D) axisParent).getAxis().getTableView().clearSelection();
         }
 
 
@@ -305,7 +301,8 @@ public class Table1DView extends TableView {
             cell.getDataCell().setLiveDataTraceValue(liveVal);
             getToolbar().setLiveDataValue(liveVal);
         }
-        table.getAxisParent().updateLiveDataHighlight();
+        
+        table.getAxisParent().getTableView().updateLiveDataHighlight();
     }
 
     public boolean isAxis() {
@@ -360,7 +357,7 @@ public class Table1DView extends TableView {
 
     @Override
     public void updateTableLabel() {
-        this.table.getAxisParent().updateTableLabel();
+        this.table.getAxisParent().getTableView().updateTableLabel();
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -24,7 +24,7 @@ import java.awt.BorderLayout;
 import javax.swing.JLabel;
 import javax.swing.border.EmptyBorder;
 
-import com.romraider.Settings;
+import com.romraider.swing.TableFrame;
 import com.romraider.util.NumberUtil;
 
 public class Table1DView extends TableView {
@@ -32,8 +32,8 @@ public class Table1DView extends TableView {
 	private static final long serialVersionUID = -8747180767803835631L;
 	private Table1D table;
 	
-    protected Table1DView(Table1D table) {
-		super(table);
+    protected Table1DView(Table1D table, TableFrame frame) {
+		super(table, frame);
     	this.table = table;
 	}
     
@@ -360,19 +360,4 @@ public class Table1DView extends TableView {
         this.table.getAxisParent().getTableView().updateTableLabel();
     }
 
-    @Override
-    public StringBuffer getTableAsString() {
-        if(table.isStaticDataTable()) {
-            StringBuffer output = new StringBuffer(Settings.BLANK);
-            for (int i = 0; i < data.length; i++) {
-                output.append(data[i].getStaticText());
-                if (i < data.length - 1) {
-                    output.append(Settings.TAB);
-                }
-            }
-            return output;
-        } else {
-            return super.getTableAsString();
-        }
-    }
 }

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -82,7 +82,8 @@ public class Table1DView extends TableView {
 	        if(tableLabel != null)
 	        	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));	       
     	}
-    	else if(table.getType() != TableType.X_AXIS && table.getType() != TableType.Y_AXIS)
+    	
+    	if(table.getType() != TableType.X_AXIS && table.getType() != TableType.Y_AXIS)
     		if(presetPanel != null) presetPanel.populatePanel();
     }
 
@@ -95,7 +96,7 @@ public class Table1DView extends TableView {
     public void cursorUp() {
         if (table.getType() == Table.TableType.Y_AXIS) {
             if (highlightY > 0 && data[highlightY].isSelected()) {
-                selectCellAt(highlightY - 1);
+                table.selectCellAt(highlightY - 1);
             }
         } else if (table.getType() == Table.TableType.X_AXIS) {
             // Y axis is on top.. nothing happens
@@ -109,15 +110,15 @@ public class Table1DView extends TableView {
         if (table.getType() == Table.TableType.Y_AXIS) {
             if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
                 if (highlightY < table.getDataSize() - 1 && data[highlightY].isSelected()) {
-                    selectCellAt(highlightY + 1);
+                    table.selectCellAt(highlightY + 1);
                 }
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
-                	selectCellAt(highlightY);
+                	table.selectCellAt(highlightY);
                 }
             }
         } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
+            ((Table3D) table.getAxisParent()).selectCellAt(highlightY);
         } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move down to
         }
@@ -129,16 +130,16 @@ public class Table1DView extends TableView {
             // X axis is on left.. nothing happens
             if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
-                    selectCellAt(highlightY - 1);
+                    table.selectCellAt(highlightY - 1);
                 }
             }
         } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
             if (highlightY > 0) {
-                selectCellAt(highlightY - 1);
+                table.selectCellAt(highlightY - 1);
             }
         } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
             if (highlightY > 0) {
-                selectCellAt(highlightY - 1);
+                table.selectCellAt(highlightY - 1);
             }
         }
     }
@@ -147,17 +148,17 @@ public class Table1DView extends TableView {
     public void cursorRight() {
         if (table.getType() == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
             if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
+                ((Table3D) table.getAxisParent()).selectCellAt(highlightY);
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
-                selectCellAt(highlightY + 1);
+                table.selectCellAt(highlightY + 1);
             }
         } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
             if (highlightY < table.getDataSize() - 1) {
-                selectCellAt(highlightY + 1);
+                table.selectCellAt(highlightY + 1);
             }
         } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
             if (highlightY < table.getDataSize() - 1) {
-                selectCellAt(highlightY + 1);
+                table.selectCellAt(highlightY + 1);
             }
         }
     }
@@ -166,7 +167,7 @@ public class Table1DView extends TableView {
 	public void shiftCursorUp() {
         if (table.getType() == Table.TableType.Y_AXIS) {
             if (highlightY > 0 && data[highlightY].isSelected()) {
-            	selectCellAtWithoutClear(highlightY - 1);
+            	table.selectCellAtWithoutClear(highlightY - 1);
             }
         } else if (table.getType() == Table.TableType.X_AXIS) {
             // Y axis is on top.. nothing happens
@@ -180,15 +181,15 @@ public class Table1DView extends TableView {
         if (table.getType() == Table.TableType.Y_AXIS) {
             if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
                 if (highlightY < table.getDataSize() - 1 && data[highlightY].isSelected()) {
-                	selectCellAtWithoutClear(highlightY + 1);
+                	table.selectCellAtWithoutClear(highlightY + 1);
                 }
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
-                    table.getAxisParent().getTableView().selectCellAtWithoutClear(highlightY);
+                    table.getAxisParent().getTableView().table.selectCellAtWithoutClear(highlightY);
                 }
             }
         } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
-            ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
+            ((Table3D) table.getAxisParent()).selectCellAt(highlightY);
         } else if (table.getType() == Table.TableType.TABLE_1D) {
             // no where to move down to
         }
@@ -200,16 +201,16 @@ public class Table1DView extends TableView {
             // X axis is on left.. nothing happens
             if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
                 if (data[highlightY].isSelected()) {
-                	selectCellAtWithoutClear(highlightY - 1);
+                	table.selectCellAtWithoutClear(highlightY - 1);
                 }
             }
         } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
             if (highlightY > 0) {
-            	selectCellAtWithoutClear(highlightY - 1);
+            	table.selectCellAtWithoutClear(highlightY - 1);
             }
         } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
             if (highlightY > 0) {
-            	selectCellAtWithoutClear(highlightY - 1);
+            	table.selectCellAtWithoutClear(highlightY - 1);
             }
         }
 	}
@@ -218,17 +219,17 @@ public class Table1DView extends TableView {
 	public void shiftCursorRight() {
         if (table.getType() == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
             if (table.getAxisParent().getType() == Table.TableType.TABLE_3D) {
-                ((Table3D) table.getAxisParent()).getTableView().selectCellAt(highlightY);
+                ((Table3D) table.getAxisParent()).selectCellAt(highlightY);
             } else if (table.getAxisParent().getType() == Table.TableType.TABLE_2D) {
-            	selectCellAtWithoutClear(highlightY + 1);
+            	table.selectCellAtWithoutClear(highlightY + 1);
             }
         } else if (table.getType() == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
             if (highlightY < table.getDataSize() - 1) {
-            	selectCellAtWithoutClear(highlightY + 1);
+            	table.selectCellAtWithoutClear(highlightY + 1);
             }
         } else if (table.getType() == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
             if (highlightY < table.getDataSize() - 1) {
-            	selectCellAtWithoutClear(highlightY + 1);
+            	table.selectCellAtWithoutClear(highlightY + 1);
             }
         }
 	}
@@ -238,7 +239,7 @@ public class Table1DView extends TableView {
     	Table p = table.getAxisParent();
     	
     	if(p != null)
-    		p.getTableView().clearSelection();
+    		p.clearSelection();
     }
 
     @Override
@@ -246,17 +247,17 @@ public class Table1DView extends TableView {
         Table axisParent = table.getAxisParent();
         
         if(axisParent != null)
-        	axisParent.getTableView().clearSelection();
+        	axisParent.clearSelection();
 
         if(axisParent instanceof Table3D) {
             Table3D table3D = (Table3D) axisParent;
             if(table.getType() == Table.TableType.X_AXIS) {
-                table3D.getYAxis().getTableView().clearSelection();
+                table3D.getYAxis().clearSelection();
             } else if (table.getType() == Table.TableType.Y_AXIS) {
-                table3D.getXAxis().getTableView().clearSelection();
+                table3D.getXAxis().clearSelection();
             }
         } else if (axisParent instanceof Table2D) {
-            ((Table2D) axisParent).getAxis().getTableView().clearSelection();
+            ((Table2D) axisParent).getAxis().clearSelection();
         }
 
 

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -1,0 +1,404 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2021 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.maps;
+
+import java.awt.BorderLayout;
+
+import javax.swing.JLabel;
+import javax.swing.border.EmptyBorder;
+
+import com.romraider.Settings;
+import com.romraider.util.NumberUtil;
+
+public class Table1D extends Table {
+    private static final long serialVersionUID = -8747180767803835631L;
+    private Table axisParent = null;
+    private final TableType type;
+
+    public Table1D(TableType type) {
+        this.type = type;
+    }
+
+    @Override
+    public TableType getType() {
+        return type;
+    }
+
+    public void setAxisParent(Table axisParent) {
+        this.axisParent = axisParent;
+    }
+
+    public Table getAxisParent() {
+        return axisParent;
+    }
+
+    public void addStaticDataCell(DataCellView input) {
+        for(int i = 0; i < data.length; i++) {
+            if(data[i] == null) {
+                data[i] = input;
+                data[i].setY(i);
+                break;
+            }
+        }
+    }
+    
+	@Override
+	public byte[] saveFile(byte[] binData) {
+		return binData;
+	}
+	
+    @Override
+    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
+        centerLayout.setRows(1);
+        centerLayout.setColumns(this.getDataSize());
+
+        super.populateTable(input, romRamOffset);
+
+        // add to table
+        for (int i = 0; i < this.getDataSize(); i++) {
+            centerPanel.add(this.getDataCell(i));
+        }
+
+        if(null == name || name.isEmpty()) {
+            ;// Do not add label.
+        } else if(null == getCurrentScale () || "0x" == getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            tableLabel = new JLabel(getName(), JLabel.CENTER);
+            add(tableLabel, BorderLayout.NORTH);
+        } else {
+            tableLabel = new JLabel(getName() + " (" + getCurrentScale().getUnit() + ")", JLabel.CENTER);
+            add(tableLabel, BorderLayout.NORTH);
+        }
+        
+        if(tableLabel != null)
+        	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));
+        
+        if(presetPanel != null) presetPanel.populatePanel();
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " (1D)";
+    }
+
+    @Override
+    public void cursorUp() {
+        if (type == Table.TableType.Y_AXIS) {
+            if (highlightY > 0 && data[highlightY].isSelected()) {
+                selectCellAt(highlightY - 1);
+            }
+        } else if (type == Table.TableType.X_AXIS) {
+            // Y axis is on top.. nothing happens
+        } else if (type == Table.TableType.TABLE_1D) {
+            // no where to move up to
+        }
+    }
+
+    @Override
+    public void cursorDown() {
+        if (type == Table.TableType.Y_AXIS) {
+            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                if (highlightY < getDataSize() - 1 && data[highlightY].isSelected()) {
+                    selectCellAt(highlightY + 1);
+                }
+            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+                if (data[highlightY].isSelected()) {
+                    getAxisParent().selectCellAt(highlightY);
+                }
+            }
+        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
+        } else if (type == Table.TableType.TABLE_1D) {
+            // no where to move down to
+        }
+    }
+
+    @Override
+    public void cursorLeft() {
+        if (type == Table.TableType.Y_AXIS) {
+            // X axis is on left.. nothing happens
+            if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+                if (data[highlightY].isSelected()) {
+                    selectCellAt(highlightY - 1);
+                }
+            }
+        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            if (highlightY > 0) {
+                selectCellAt(highlightY - 1);
+            }
+        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+            if (highlightY > 0) {
+                selectCellAt(highlightY - 1);
+            }
+        }
+    }
+
+    @Override
+    public void cursorRight() {
+        if (type == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
+            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
+            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+                selectCellAt(highlightY + 1);
+            }
+        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            if (highlightY < getDataSize() - 1) {
+                selectCellAt(highlightY + 1);
+            }
+        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+            if (highlightY < getDataSize() - 1) {
+                selectCellAt(highlightY + 1);
+            }
+        }
+    }
+
+	@Override
+	public void shiftCursorUp() {
+        if (type == Table.TableType.Y_AXIS) {
+            if (highlightY > 0 && data[highlightY].isSelected()) {
+            	selectCellAtWithoutClear(highlightY - 1);
+            }
+        } else if (type == Table.TableType.X_AXIS) {
+            // Y axis is on top.. nothing happens
+        } else if (type == Table.TableType.TABLE_1D) {
+            // no where to move up to
+        }
+	}
+
+	@Override
+	public void shiftCursorDown() {
+        if (type == Table.TableType.Y_AXIS) {
+            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                if (highlightY < getDataSize() - 1 && data[highlightY].isSelected()) {
+                	selectCellAtWithoutClear(highlightY + 1);
+                }
+            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+                if (data[highlightY].isSelected()) {
+                    getAxisParent().selectCellAtWithoutClear(highlightY);
+                }
+            }
+        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
+        } else if (type == Table.TableType.TABLE_1D) {
+            // no where to move down to
+        }
+	}
+
+	@Override
+	public void shiftCursorLeft() {
+        if (type == Table.TableType.Y_AXIS) {
+            // X axis is on left.. nothing happens
+            if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+                if (data[highlightY].isSelected()) {
+                	selectCellAtWithoutClear(highlightY - 1);
+                }
+            }
+        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            if (highlightY > 0) {
+            	selectCellAtWithoutClear(highlightY - 1);
+            }
+        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+            if (highlightY > 0) {
+            	selectCellAtWithoutClear(highlightY - 1);
+            }
+        }
+	}
+
+	@Override
+	public void shiftCursorRight() {
+        if (type == Table.TableType.Y_AXIS && data[highlightY].isSelected()) {
+            if (getAxisParent().getType() == Table.TableType.TABLE_3D) {
+                ((Table3D) getAxisParent()).selectCellAt(highlightY, this);
+            } else if (getAxisParent().getType() == Table.TableType.TABLE_2D) {
+            	selectCellAtWithoutClear(highlightY + 1);
+            }
+        } else if (type == Table.TableType.X_AXIS && data[highlightY].isSelected()) {
+            if (highlightY < getDataSize() - 1) {
+            	selectCellAtWithoutClear(highlightY + 1);
+            }
+        } else if (type == Table.TableType.TABLE_1D && data[highlightY].isSelected()) {
+            if (highlightY < getDataSize() - 1) {
+            	selectCellAtWithoutClear(highlightY + 1);
+            }
+        }
+	}
+
+    @Override
+    public void clearSelection() {
+        // Call to the axis parent.  The axis parent should then call to clear this data.
+    	Table p = getAxisParent();
+    	
+    	if(p != null)
+    		p.clearSelection();
+    }
+
+    @Override
+    public void startHighlight(int x, int y) {
+        Table axisParent = getAxisParent();
+        
+        if(axisParent != null)
+        	axisParent.clearSelectedData();
+
+        if(axisParent instanceof Table3D) {
+            Table3D table3D = (Table3D) axisParent;
+            if(getType() == Table.TableType.X_AXIS) {
+                table3D.getYAxis().clearSelectedData();
+            } else if (getType() == Table.TableType.Y_AXIS) {
+                table3D.getXAxis().clearSelectedData();
+            }
+        } else if (axisParent instanceof Table2D) {
+            ((Table2D) axisParent).getAxis().clearSelectedData();
+        }
+
+
+        super.startHighlight(x, y);
+    }
+
+    @Override
+    public String getCellAsString(int index) {
+        return data[index].getText();
+    }
+
+    @Override
+    public void highlightLiveData(String liveVal) {
+        if (getOverlayLog()) {
+            double liveValue = 0.0;
+            try {
+                liveValue = NumberUtil.doubleValue(liveVal);
+            } catch (Exception ex) {
+            	LOGGER.error("Table1D - live data highlight parsing error for value: " + liveVal);
+                return;
+            }
+
+            int startIdx = data.length;
+            for (int i = 0; i < data.length; i++) {
+                double currentValue = 0.0;
+                if(isStaticDataTable() && null != data[i].getStaticText()) {
+                    try {
+                        currentValue = Double.parseDouble(data[i].getStaticText());
+                    } catch(NumberFormatException nex) {
+                        return;
+                    }
+                } else {
+                    currentValue = data[i].getDataCell().getRealValue();
+                }
+
+                if (liveValue == currentValue) {
+                    startIdx = i;
+                    break;
+                } else if (liveValue < currentValue){
+                    startIdx = i-1;
+                    break;
+                }
+            }
+
+            setLiveDataIndex(startIdx);
+            DataCellView cellp = data[getPreviousLiveDataIndex()];
+            cellp.setPreviousLiveDataTrace(true);
+            DataCellView cell = data[getLiveDataIndex()];
+            cell.setPreviousLiveDataTrace(false);
+            cell.setLiveDataTrace(true);
+            cell.getDataCell().setLiveDataTraceValue(liveVal);
+            getToolbar().setLiveDataValue(liveVal);
+        }
+        getAxisParent().updateLiveDataHighlight();
+    }
+
+    @Override
+    public boolean isLiveDataSupported() {
+        return false;
+    }
+
+    @Override
+    public boolean isButtonSelected() {
+        return true;
+    }
+
+    public boolean isAxis() {
+        return getType() == Table.TableType.X_AXIS ||
+                getType() == Table.TableType.Y_AXIS || isStaticDataTable();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        try {
+            if(null == other) {
+                return false;
+            }
+
+            if(other == this) {
+                return true;
+            }
+
+            if(!(other instanceof Table1D)) {
+                return false;
+            }
+
+            Table1D otherTable = (Table1D)other;
+
+            if(this.isAxis() != otherTable.isAxis()) {
+                return false;
+            }
+
+            if(this.data.length != otherTable.data.length)
+            {
+                return false;
+            }
+
+            if(this.data.equals(otherTable.data))
+            {
+                return true;
+            }
+
+            // Compare Bin Values
+            for(int i=0 ; i < this.data.length ; i++) {
+                if(! this.data[i].equals(otherTable.data[i])) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch(Exception ex) {
+            // TODO: Log Exception.
+            return false;
+        }
+    }
+
+    @Override
+    public void updateTableLabel() {
+        this.getAxisParent().updateTableLabel();
+    }
+
+    @Override
+    public StringBuffer getTableAsString() {
+        if(isStaticDataTable()) {
+            StringBuffer output = new StringBuffer(Settings.BLANK);
+            for (int i = 0; i < data.length; i++) {
+                output.append(data[i].getStaticText());
+                if (i < data.length - 1) {
+                    output.append(Settings.TAB);
+                }
+            }
+            return output;
+        } else {
+            return super.getTableAsString();
+        }
+    }
+}

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -24,7 +24,6 @@ import java.awt.BorderLayout;
 import javax.swing.JLabel;
 import javax.swing.border.EmptyBorder;
 
-import com.romraider.swing.TableFrame;
 import com.romraider.util.NumberUtil;
 
 public class Table1DView extends TableView {
@@ -32,9 +31,10 @@ public class Table1DView extends TableView {
 	private static final long serialVersionUID = -8747180767803835631L;
 	private Table1D table;
 	
-    protected Table1DView(Table1D table, TableFrame frame) {
-		super(table, frame);
+    public Table1DView(Table1D table) {
+		super(table);
     	this.table = table;
+    	populateTableVisual();
 	}
     
     public void addStaticDataCell(DataCellView input) {
@@ -47,12 +47,11 @@ public class Table1DView extends TableView {
         }
     }
     
-	
     @Override
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
+    public void populateTableVisual()   {
         centerLayout.setRows(1);
         centerLayout.setColumns(table.getDataSize());
-
+        super.populateTableVisual();
 
         // add to table
         for (int i = 0; i < table.getDataSize(); i++) {
@@ -223,8 +222,7 @@ public class Table1DView extends TableView {
         }
 	}
 
-    @Override
-    public void clearSelection() {
+    public void clearSelectionInParent() {
         // Call to the axis parent. The axis parent should then call to clear this data.
     	Table p = table.getAxisParent();
     	

--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -33,12 +33,17 @@ public class Table1DView extends TableView {
 	private Table1D table;
 	
     public Table1DView(Table1D table) {
+		this(table, false);
+	}
+    
+    public Table1DView(Table1D table, boolean hide) {
 		super(table);
     	this.table = table;
+    	this.hide = hide;
     	
     	populateTableVisual();
 	}
-    
+       
     public void addStaticDataCell(DataCellView input) {
         for(int i = 0; i < data.length; i++) {
             if(data[i] == null) {
@@ -54,7 +59,7 @@ public class Table1DView extends TableView {
         super.populateTableVisual();
         
         //Only populate the rest if we aren't an axis
-    	if(table.getType() == TableType.TABLE_1D) {
+    	if(table.getType() != TableType.X_AXIS && table.getType() != TableType.Y_AXIS && !isHidden()) {
 	        centerLayout.setRows(1);
 	        centerLayout.setColumns(table.getDataSize());
 
@@ -75,10 +80,10 @@ public class Table1DView extends TableView {
 	        }
 	        
 	        if(tableLabel != null)
-	        	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));
-	        
-	        if(presetPanel != null) presetPanel.populatePanel();
+	        	tableLabel.setBorder(new EmptyBorder(2, 4, 2, 4));	       
     	}
+    	else if(table.getType() != TableType.X_AXIS && table.getType() != TableType.Y_AXIS)
+    		if(presetPanel != null) presetPanel.populatePanel();
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -26,7 +26,7 @@ import com.romraider.util.SettingsManager;
 
 public class Table2D extends Table {
     private static final long serialVersionUID = -7684570967109324784L;
-    private Table1D axis;
+    private Table1D axis = new Table1D(TableType.Y_AXIS);
 
     @Override
     public TableType getType() {
@@ -78,12 +78,8 @@ public class Table2D extends Table {
 
     @Override
     public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {   	
-        try {
             axis.populateTable(rom);
             super.populateTable(rom);
-        } catch (ArrayIndexOutOfBoundsException ex) {
-            throw new ArrayIndexOutOfBoundsException();
-        }
     }
 
 

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -20,36 +20,13 @@
 package com.romraider.maps;
 
 import static com.romraider.util.ParamChecker.isNullOrEmpty;
-
-import java.awt.BorderLayout;
-import java.awt.Cursor;
-import java.awt.Dimension;
-import java.awt.Toolkit;
-import java.awt.Window;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.event.KeyListener;
-import java.io.IOException;
-import java.util.StringTokenizer;
-
 import javax.naming.NameNotFoundException;
-import javax.swing.JLabel;
-import javax.swing.SwingUtilities;
-import javax.swing.SwingWorker;
-import javax.swing.border.EmptyBorder;
-
 import com.romraider.Settings;
-import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.util.SettingsManager;
 
 public class Table2D extends Table {
     private static final long serialVersionUID = -7684570967109324784L;
-    private Table1D axis = new Table1D(Table.TableType.Y_AXIS);
-
-    private CopyTable2DWorker copyTable2DWorker;
-    private CopySelection2DWorker copySelection2DWorker;
-
+    private Table1D axis;
 
     @Override
     public TableType getType() {
@@ -159,6 +136,7 @@ public class Table2D extends Table {
                 try {
                     this.axis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
                 } catch (NameNotFoundException e1) {
+                	e1.printStackTrace();
                 }
             }
         }

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -46,14 +46,10 @@ import com.romraider.util.SettingsManager;
 public class Table2D extends Table {
     private static final long serialVersionUID = -7684570967109324784L;
     private Table1D axis = new Table1D(Table.TableType.Y_AXIS);
-    private JLabel axisLabel;
 
     private CopyTable2DWorker copyTable2DWorker;
     private CopySelection2DWorker copySelection2DWorker;
 
-    public Table2D() {
-        verticalOverhead += 18;
-    }
 
     @Override
     public TableType getType() {
@@ -64,13 +60,6 @@ public class Table2D extends Table {
         return axis;
     }
     
-    public JLabel getAxisLabel() {
-    	return axisLabel;
-    }
-    
-    public void setAxisLabel(JLabel label) {
-    	axisLabel = label;
-    }
     
     public void setAxis(Table1D axis) {
         this.axis = axis;
@@ -80,8 +69,8 @@ public class Table2D extends Table {
     @Override
     public String toString() {
         return super.toString() + " (2D)";// + axis;
-    }
-
+    }    
+    
     @Override
     public void populateCompareValues(Table otherTable) {
         if(null == otherTable || !(otherTable instanceof Table2D)) {
@@ -105,93 +94,15 @@ public class Table2D extends Table {
     }
 
     @Override
-    public StringBuffer getTableAsString() {
-        StringBuffer output = new StringBuffer(Settings.BLANK);
-        output.append(axis.getTableAsString());
-        output.append(Settings.NEW_LINE);
-        output.append(super.getTableAsString());
-        return output;
-    }
-
-    @Override
-    public Dimension getFrameSize() {
-        int height = verticalOverhead + cellHeight * 2;
-        int width = horizontalOverhead + data.length * cellWidth;
-        if (height < minHeight) {
-            height = minHeight;
-        }
-        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
-        if (width < minWidth) {
-            width = minWidth;
-        }
-        return new Dimension(width, height);
-    }
-
-    @Override
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
-    	this.input = input;
-    	centerLayout.setRows(2);
-        centerLayout.setColumns(this.getDataSize());
-
+    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {   	
         try {
             axis.populateTable(input, romRamOffset);
             super.populateTable(input, romRamOffset);
         } catch (ArrayIndexOutOfBoundsException ex) {
             throw new ArrayIndexOutOfBoundsException();
         }
-
-        // add to table
-        for (int i = 0; i < this.getDataSize(); i++) {
-            centerPanel.add(axis.getDataCell(i));
-        }
-        if (flip) {
-            for (int i = this.getDataSize() - 1; i >= 0; i--) {
-                centerPanel.add(this.getDataCell(i));
-            }
-        } else {
-            for (int i = 0; i < this.getDataSize(); i++) {
-                centerPanel.add(this.getDataCell(i));
-            }
-        }
-
-        if(null == axis.getName() || axis.getName().isEmpty() || Settings.BLANK == axis.getName()) {
-            ;// Do not add label.
-        } else if(null == axis.getCurrentScale() || "0x" == axis.getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            axisLabel = new JLabel(axis.getName(), JLabel.CENTER);
-            add(axisLabel, BorderLayout.NORTH);
-        } else {
-            axisLabel = new JLabel(axis.getName() + " (" + axis.getCurrentScale().getUnit() + ")", JLabel.CENTER);
-            add(axisLabel, BorderLayout.NORTH);
-        }
-
-        tableLabel = new JLabel(getCurrentScale().getUnit(), JLabel.CENTER);
-        add(tableLabel, BorderLayout.SOUTH);      
-        axisLabel.setBorder(new EmptyBorder(2, 4, 2, 4));   
-        
-        if(presetPanel != null) presetPanel.populatePanel();
-        repaint();
     }
 
-    @Override
-    public void updateTableLabel() {
-        if(null == axis.getName() || axis.getName().length() < 1 || Settings.BLANK == axis.getName()) {
-            ;// Do not update label.
-        } else if(null == axis.getCurrentScale() || "0x" == axis.getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            axisLabel.setText(axis.getName());
-        } else {
-            axisLabel.setText(axis.getName() + " (" + axis.getCurrentScale().getUnit() + ")");
-        }
-
-        tableLabel.setText(getCurrentScale().getUnit());
-    }
-
-    @Override
-    public void clearSelection() {
-        axis.clearSelectedData();
-        clearSelectedData();
-    }
 
     @Override
     public void setRevertPoint() {
@@ -200,7 +111,7 @@ public class Table2D extends Table {
     }
 
     @Override
-    public void undoAll() {
+    public void undoAll() throws UserLevelException {
         super.undoAll();
         axis.undoAll();
     }
@@ -216,190 +127,13 @@ public class Table2D extends Table {
     }
 
     @Override
-    public void addKeyListener(KeyListener listener) {
-        super.addKeyListener(listener);
-        axis.addKeyListener(listener);
+    public String getLogParamString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(axis.getLogParamString()+ ", ");
+        sb.append(getName()+ ":" + getLogParam());
+        return sb.toString();
     }
-
-    @Override
-    public void cursorUp() {
-        if (data[highlightY].isSelected()) {
-            axis.selectCellAt(highlightY);
-        }
-    }
-
-    @Override
-    public void drawTable() {
-        super.drawTable();
-        axis.drawTable();
-    }
-
-    @Override
-    public void cursorDown() {
-        axis.cursorDown();
-    }
-
-    @Override
-    public void cursorLeft() {
-        if (highlightY > 0 && data[highlightY].isSelected()) {
-            selectCellAt(highlightY - 1);
-        } else {
-            axis.cursorLeft();
-        }
-    }
-
-    @Override
-    public void cursorRight() {
-        if (highlightY < data.length - 1 && data[highlightY].isSelected()) {
-            selectCellAt(highlightY + 1);
-        } else {
-            axis.cursorRight();
-        }
-    }
-
-	@Override
-	public void shiftCursorUp() {
-        if (data[highlightY].isSelected()) {
-        	data[highlightY].setSelected(false);
-        }
-        axis.selectCellAt(highlightY);
-	}
-
-	@Override
-	public void shiftCursorDown() {
-        axis.cursorDown();
-	}
-
-	@Override
-	public void shiftCursorLeft() {
-        if (highlightY > 0 && data[highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightY - 1);
-        } else {
-        	axis.shiftCursorLeft();
-        }
-	}
-
-	@Override
-	public void shiftCursorRight() {
-        if (highlightY < data.length - 1 && data[highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightY + 1);
-        } else {
-        	axis.shiftCursorRight();
-        }
-	}
-
-    @Override
-    public void startHighlight(int x, int y) {
-        axis.clearSelectedData();
-        super.startHighlight(x, y);
-    }
-
-    @Override
-    public void copySelection() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        }
-        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        super.copySelection();
-        copySelection2DWorker = new CopySelection2DWorker(this);
-        copySelection2DWorker.execute();
-    }
-
-    @Override
-    public void copyTable() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        }
-        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        copyTable2DWorker = new CopyTable2DWorker(this);
-        copyTable2DWorker.execute();
-    }
-
-    @Override
-    public void paste() {
-        StringTokenizer st = new StringTokenizer(Settings.BLANK);
-        String input = Settings.BLANK;
-        try {
-            input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
-            st = new StringTokenizer(input, ST_DELIMITER);
-        } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
-        } catch (IOException ex) {
-        }
-
-        String pasteType = st.nextToken();
-
-        if (pasteType.equalsIgnoreCase("[Table2D]")) { // Paste table
-            String currentToken = st.nextToken(Settings.NEW_LINE);
-            if (currentToken.endsWith("\t")) {
-                currentToken = st.nextToken(Settings.NEW_LINE);
-            }
-
-            String axisValues = "[Table1D]" + Settings.NEW_LINE + currentToken;
-            String dataValues = "[Table1D]" + Settings.NEW_LINE + st.nextToken(Settings.NEW_LINE);
-
-            // put axis in clipboard and paste
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(axisValues), null);
-            axis.paste();
-            // put datavalues in clipboard and paste
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(dataValues), null);
-            super.paste();
-            // reset clipboard
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(input), null);
-
-        } else if (pasteType.equalsIgnoreCase("[Selection1D]")) { // paste selection
-            if (data[highlightY].isSelected()) {
-                super.paste();
-            } else {
-                axis.paste();
-            }
-        }
-    }
-
-    @Override
-    public void interpolate() {
-        super.interpolate();
-        this.getAxis().interpolate();
-    }
-
-    @Override
-    public void verticalInterpolate() {
-        super.verticalInterpolate();
-        this.getAxis().verticalInterpolate();
-    }
-
-    @Override
-    public void horizontalInterpolate() {
-        int[] coords = { getDataSize(), 0};
-        DataCellView[] tableData = getData();
-        DataCellView[] axisData = getAxis().getData();
-
-        for (int i = 0; i < getDataSize(); ++i) {
-            if (tableData[i].isSelected()) {
-                if (i < coords[0])
-                    coords[0] = i;
-                if (i > coords[1])
-                    coords[1] = i;
-            }
-        }
-        if (coords[1] - coords[0] > 1) {
-            double x, x1, x2, y1, y2;
-            x1 = axisData[coords[0]].getDataCell().getBinValue();
-            y1 = tableData[coords[0]].getDataCell().getBinValue();
-            x2 = axisData[coords[1]].getDataCell().getBinValue();
-            y2 = tableData[coords[1]].getDataCell().getBinValue();
-            for (int i = coords[0] + 1; i < coords[1]; ++i) {
-                x = axisData[i].getDataCell().getBinValue();
-                data[i].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
-            }
-        }
-        // Interpolate x axis in case the x axis in selected.
-        this.getAxis().horizontalInterpolate();
-    }
-
+    
     @Override
     public boolean isLiveDataSupported() {
         return !isNullOrEmpty(axis.getLogParam());
@@ -409,42 +143,7 @@ public class Table2D extends Table {
     public boolean isButtonSelected() {
         return true;
     }
-
-    @Override
-    public void clearLiveDataTrace() {
-        super.clearLiveDataTrace();
-        axis.clearLiveDataTrace();
-    }
-
-    @Override
-    public void updateLiveDataHighlight() {
-        if (getOverlayLog()) {
-            data[axis.getPreviousLiveDataIndex()].setPreviousLiveDataTrace(true);
-            data[axis.getLiveDataIndex()].setPreviousLiveDataTrace(false);
-            data[axis.getLiveDataIndex()].setLiveDataTrace(true);
-        }
-    }
-
-    @Override
-    public String getLogParamString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(axis.getLogParamString()+ ", ");
-        sb.append(getName()+ ":" + getLogParam());
-        return sb.toString();
-    }
-
-    @Override
-    public void setOverlayLog(boolean overlayLog) {
-        super.setOverlayLog(overlayLog);
-        axis.setOverlayLog(overlayLog);
-    }
-
-    @Override
-    public void setCompareDisplay(Settings.CompareDisplay compareDisplay) {
-        super.setCompareDisplay(compareDisplay);
-        axis.setCompareDisplay(compareDisplay);
-    }
-
+  
     @Override
     public void setCompareValueType(Settings.DataType compareValueType) {
         super.setCompareValueType(compareValueType);
@@ -464,8 +163,6 @@ public class Table2D extends Table {
             }
         }
         this.curScale = curScale;
-        updateTableLabel();
-        drawTable();
     }
 
     @Override
@@ -518,70 +215,5 @@ public class Table2D extends Table {
             // TODO: Log Exception.
             return false;
         }
-    }
-
-    @Override
-    public void repaint() {
-        super.repaint();
-        if(null != axis) {
-            axis.repaint();
-        }
     }  
-}
-
-class CopySelection2DWorker extends SwingWorker<Void, Void> {
-    Table2D table;
-    Table extendedTable;
-
-    public CopySelection2DWorker(Table2D table)
-    {
-        this.table = table;
-    }
-
-    @Override
-    protected Void doInBackground() throws Exception {
-        table.getAxis().copySelection();
-        return null;
-    }
-
-    @Override
-    public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(null);
-        }
-        table.setCursor(null);
-        ECUEditorManager.getECUEditor().setCursor(null);
-    }
-}
-
-class CopyTable2DWorker extends SwingWorker<Void, Void> {
-    Table2D table;
-
-    public CopyTable2DWorker(Table2D table)
-    {
-        this.table = table;
-    }
-
-    @Override
-    protected Void doInBackground() throws Exception {
-        String tableHeader = table.getSettings().getTable2DHeader();
-        StringBuffer output = new StringBuffer(tableHeader);
-        output.append(table.getTableAsString());
-
-        //copy to clipboard
-        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(output.toString()), null);
-        return null;
-
-    }
-
-    @Override
-    public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(null);
-        }
-        table.setCursor(null);
-        ECUEditorManager.getECUEditor().setCursor(null);
-    }
 }

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -164,6 +164,15 @@ public class Table2D extends Table {
         }
         this.curScale = curScale;
     }
+    
+    @Override
+    public StringBuffer getTableAsString() {
+        StringBuffer output = new StringBuffer(Settings.BLANK);
+        output.append(axis.getTableAsString());
+        output.append(Settings.NEW_LINE);
+        output.append(super.getTableAsString());
+        return output;
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -164,7 +164,7 @@ public class Table2D extends Table {
         }
         this.curScale = curScale;
         
-        if(tableView != null) tableView.repaint();
+        if(tableView != null) tableView.drawTable();
     }
     
     @Override

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -163,6 +163,8 @@ public class Table2D extends Table {
             }
         }
         this.curScale = curScale;
+        
+        if(tableView != null) tableView.repaint();
     }
     
     @Override

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -94,11 +94,7 @@ public class Table2D extends Table {
     
 
     @Override
-    public byte[] saveFile(byte[] binData) {
-        /*
-        binData = super.saveFile(binData);
-        binData = axis.saveFile(binData);*/
-    	
+    public byte[] saveFile(byte[] binData) {  	
         return binData;
     }
 

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -48,6 +48,13 @@ public class Table2D extends Table {
     }    
     
     @Override
+    public void clearData() {
+    	super.clearData();
+    	axis.clearData();
+    	axis=null;
+    }
+    
+    @Override
     public void populateCompareValues(Table otherTable) {
         if(null == otherTable || !(otherTable instanceof Table2D)) {
             return;
@@ -70,10 +77,10 @@ public class Table2D extends Table {
     }
 
     @Override
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {   	
+    public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {   	
         try {
-            axis.populateTable(input, romRamOffset);
-            super.populateTable(input, romRamOffset);
+            axis.populateTable(rom);
+            super.populateTable(rom);
         } catch (ArrayIndexOutOfBoundsException ex) {
             throw new ArrayIndexOutOfBoundsException();
         }

--- a/src/main/java/com/romraider/maps/Table2D.java
+++ b/src/main/java/com/romraider/maps/Table2D.java
@@ -36,8 +36,7 @@ public class Table2D extends Table {
     public Table1D getAxis() {
         return axis;
     }
-    
-    
+       
     public void setAxis(Table1D axis) {
         this.axis = axis;
         axis.setAxisParent(this);
@@ -143,6 +142,53 @@ public class Table2D extends Table {
         this.curScale = curScale;
         
         if(tableView != null) tableView.drawTable();
+    }
+    
+    @Override
+    public void clearSelection() {
+        axis.clearSelection();
+        super.clearSelection();
+    }
+    
+    @Override
+    public void interpolate() throws UserLevelException {
+        super.interpolate();
+        this.getAxis().interpolate();
+    }
+
+    @Override
+    public void verticalInterpolate() throws UserLevelException {
+        super.verticalInterpolate();
+        this.getAxis().verticalInterpolate();
+    }
+
+    @Override
+    public void horizontalInterpolate() throws UserLevelException {
+        int[] coords = { getDataSize(), 0};
+        DataCell[] tableData = getData();
+        DataCell[] axisData = getAxis().getData();
+
+        for (int i = 0; i < getDataSize(); ++i) {
+            if (tableData[i].isSelected()) {
+                if (i < coords[0])
+                    coords[0] = i;
+                if (i > coords[1])
+                    coords[1] = i;
+            }
+        }
+        if (coords[1] - coords[0] > 1) {
+            double x, x1, x2, y1, y2;
+            x1 = axisData[coords[0]].getBinValue();
+            y1 = tableData[coords[0]].getBinValue();
+            x2 = axisData[coords[1]].getBinValue();
+            y2 = tableData[coords[1]].getBinValue();
+            for (int i = coords[0] + 1; i < coords[1]; ++i) {
+                x = axisData[i].getBinValue();
+                data[i].setBinValue(linearInterpolation(x, x1, x2, y1, y2));
+            }
+        }
+        // Interpolate x axis in case the x axis in selected.
+        this.getAxis().horizontalInterpolate();
     }
     
     @Override

--- a/src/main/java/com/romraider/maps/Table2DView.java
+++ b/src/main/java/com/romraider/maps/Table2DView.java
@@ -141,55 +141,7 @@ public class Table2DView extends TableView {
 
         tableLabel.setText(table.getCurrentScale().getUnit());
     }
-
-    @Override
-    public void interpolate() throws UserLevelException {
-        super.interpolate();
-        this.getAxis().interpolate();
-    }
-
-    @Override
-    public void verticalInterpolate() throws UserLevelException {
-        super.verticalInterpolate();
-        this.getAxis().verticalInterpolate();
-    }
-
-    @Override
-    public void horizontalInterpolate() throws UserLevelException {
-        int[] coords = { table.getDataSize(), 0};
-        DataCellView[] tableData = getData();
-        DataCellView[] axisData = getAxis().getData();
-
-        for (int i = 0; i < table.getDataSize(); ++i) {
-            if (tableData[i].isSelected()) {
-                if (i < coords[0])
-                    coords[0] = i;
-                if (i > coords[1])
-                    coords[1] = i;
-            }
-        }
-        if (coords[1] - coords[0] > 1) {
-            double x, x1, x2, y1, y2;
-            x1 = axisData[coords[0]].getDataCell().getBinValue();
-            y1 = tableData[coords[0]].getDataCell().getBinValue();
-            x2 = axisData[coords[1]].getDataCell().getBinValue();
-            y2 = tableData[coords[1]].getDataCell().getBinValue();
-            for (int i = coords[0] + 1; i < coords[1]; ++i) {
-                x = axisData[i].getDataCell().getBinValue();
-                data[i].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
-            }
-        }
-        // Interpolate x axis in case the x axis in selected.
-        this.getAxis().horizontalInterpolate();
-    }
-    
-    @Override
-    public void clearSelection() {
-        axis.clearSelection();
-        super.clearSelection();
-    }
-
-    
+  
     @Override
     public void addKeyListener(KeyListener listener) {
         super.addKeyListener(listener);
@@ -199,7 +151,7 @@ public class Table2DView extends TableView {
     @Override
     public void cursorUp() {
         if (data[highlightY].isSelected()) {
-            axis.selectCellAt(highlightY);
+            axis.getTable().selectCellAt(highlightY);
         }
     }
 
@@ -219,7 +171,7 @@ public class Table2DView extends TableView {
     @Override
     public void cursorLeft() {
         if (highlightY > 0 && data[highlightY].isSelected()) {
-            selectCellAt(highlightY - 1);
+            table.selectCellAt(highlightY - 1);
         } else {
             axis.cursorLeft();
         }
@@ -228,7 +180,7 @@ public class Table2DView extends TableView {
     @Override
     public void cursorRight() {
         if (highlightY < data.length - 1 && data[highlightY].isSelected()) {
-            selectCellAt(highlightY + 1);
+            table.selectCellAt(highlightY + 1);
         } else {
             axis.cursorRight();
         }
@@ -237,9 +189,9 @@ public class Table2DView extends TableView {
 	@Override
 	public void shiftCursorUp() {
         if (data[highlightY].isSelected()) {
-        	data[highlightY].setSelected(false);
+        	data[highlightY].getDataCell().setSelected(false);
         }
-        axis.selectCellAt(highlightY);
+        axis.getTable().selectCellAt(highlightY);
 	}
 
 	@Override
@@ -250,7 +202,7 @@ public class Table2DView extends TableView {
 	@Override
 	public void shiftCursorLeft() {
         if (highlightY > 0 && data[highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightY - 1);
+        	table.selectCellAtWithoutClear(highlightY - 1);
         } else {
         	axis.shiftCursorLeft();
         }
@@ -259,7 +211,7 @@ public class Table2DView extends TableView {
 	@Override
 	public void shiftCursorRight() {
         if (highlightY < data.length - 1 && data[highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightY + 1);
+        	table.selectCellAtWithoutClear(highlightY + 1);
         } else {
         	axis.shiftCursorRight();
         }
@@ -267,7 +219,7 @@ public class Table2DView extends TableView {
 
     @Override
     public void startHighlight(int x, int y) {
-        axis.clearSelection();
+        axis.getTable().clearSelection();
         super.startHighlight(x, y);
     }
 

--- a/src/main/java/com/romraider/maps/Table2DView.java
+++ b/src/main/java/com/romraider/maps/Table2DView.java
@@ -38,7 +38,6 @@ import javax.swing.border.EmptyBorder;
 
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
-import com.romraider.swing.TableFrame;
 
 public class Table2DView extends TableView {
 	private static final long serialVersionUID = -7684570967109324784L;
@@ -48,11 +47,11 @@ public class Table2DView extends TableView {
     private CopyTable2DWorker copyTable2DWorker;
     private CopySelection2DWorker copySelection2DWorker;
    
-    protected Table2DView(Table2D table, TableFrame frame) {
-		super(table, frame);
-		axis = new Table1DView(table.getAxis(), frame);
+    public Table2DView(Table2D table) {
+		super(table);
+		axis = new Table1DView(table.getAxis());
         verticalOverhead += 18;
-
+        populateTableVisual();
 	}
       
 	public Table1DView getAxis() {
@@ -87,9 +86,10 @@ public class Table2DView extends TableView {
     }
 
     @Override
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+    public void populateTableVisual(){
     	centerLayout.setRows(2);
         centerLayout.setColumns(table.getDataSize());
+        super.populateTableVisual();
 
         // add to table
         for (int i = 0; i < axis.getTable().getDataSize(); i++) {
@@ -118,8 +118,10 @@ public class Table2DView extends TableView {
         }
 
         tableLabel = new JLabel(table.getCurrentScale().getUnit(), JLabel.CENTER);
-        add(tableLabel, BorderLayout.SOUTH);      
-        axisLabel.setBorder(new EmptyBorder(2, 4, 2, 4));   
+        add(tableLabel, BorderLayout.SOUTH);
+        
+        if(axisLabel != null)
+        	axisLabel.setBorder(new EmptyBorder(2, 4, 2, 4));   
         
         if(presetPanel != null) presetPanel.populatePanel();
         repaint();
@@ -183,7 +185,7 @@ public class Table2DView extends TableView {
     @Override
     public void clearSelection() {
         axis.clearSelection();
-        clearSelection();
+        super.clearSelection();
     }
 
     
@@ -203,7 +205,9 @@ public class Table2DView extends TableView {
     @Override
     public void drawTable() {
         super.drawTable();
-        axis.drawTable();
+        
+        if(axis !=null)
+        	axis.drawTable();
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table2DView.java
+++ b/src/main/java/com/romraider/maps/Table2DView.java
@@ -87,9 +87,10 @@ public class Table2DView extends TableView {
 
     @Override
     public void populateTableVisual(){
+        super.populateTableVisual();
+        
     	centerLayout.setRows(2);
         centerLayout.setColumns(table.getDataSize());
-        super.populateTableVisual();
 
         // add to table
         for (int i = 0; i < axis.getTable().getDataSize(); i++) {

--- a/src/main/java/com/romraider/maps/Table2DView.java
+++ b/src/main/java/com/romraider/maps/Table2DView.java
@@ -38,6 +38,7 @@ import javax.swing.border.EmptyBorder;
 
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
+import com.romraider.swing.TableFrame;
 
 public class Table2DView extends TableView {
 	private static final long serialVersionUID = -7684570967109324784L;
@@ -47,9 +48,9 @@ public class Table2DView extends TableView {
     private CopyTable2DWorker copyTable2DWorker;
     private CopySelection2DWorker copySelection2DWorker;
    
-    protected Table2DView(Table2D table) {
-		super(table);
-		axis = new Table1DView(table.getAxis());
+    protected Table2DView(Table2D table, TableFrame frame) {
+		super(table, frame);
+		axis = new Table1DView(table.getAxis(), frame);
         verticalOverhead += 18;
 
 	}
@@ -69,15 +70,6 @@ public class Table2DView extends TableView {
     @Override
     public String toString() {
         return super.toString() + " (2D)";// + axis;
-    }
-
-    @Override
-    public StringBuffer getTableAsString() {
-        StringBuffer output = new StringBuffer(Settings.BLANK);
-        output.append(axis.getTableAsString());
-        output.append(Settings.NEW_LINE);
-        output.append(super.getTableAsString());
-        return output;
     }
 
     @Override
@@ -419,7 +411,7 @@ class CopyTable2DWorker extends SwingWorker<Void, Void> {
     protected Void doInBackground() throws Exception {
         String tableHeader = table.getSettings().getTable2DHeader();
         StringBuffer output = new StringBuffer(tableHeader);
-        output.append(table.getTableAsString());
+        output.append(table.getTable().getTableAsString());
 
         //copy to clipboard
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(output.toString()), null);

--- a/src/main/java/com/romraider/maps/Table2DView.java
+++ b/src/main/java/com/romraider/maps/Table2DView.java
@@ -1,0 +1,587 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2021 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.maps;
+
+import static com.romraider.util.ParamChecker.isNullOrEmpty;
+
+import java.awt.BorderLayout;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.KeyListener;
+import java.io.IOException;
+import java.util.StringTokenizer;
+
+import javax.naming.NameNotFoundException;
+import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
+import javax.swing.border.EmptyBorder;
+
+import com.romraider.Settings;
+import com.romraider.editor.ecu.ECUEditorManager;
+import com.romraider.util.SettingsManager;
+
+public class Table2D extends Table {
+    private static final long serialVersionUID = -7684570967109324784L;
+    private Table1D axis = new Table1D(Table.TableType.Y_AXIS);
+    private JLabel axisLabel;
+
+    private CopyTable2DWorker copyTable2DWorker;
+    private CopySelection2DWorker copySelection2DWorker;
+
+    public Table2D() {
+        verticalOverhead += 18;
+    }
+
+    @Override
+    public TableType getType() {
+        return TableType.TABLE_2D;
+    }
+
+    public Table1D getAxis() {
+        return axis;
+    }
+    
+    public JLabel getAxisLabel() {
+    	return axisLabel;
+    }
+    
+    public void setAxisLabel(JLabel label) {
+    	axisLabel = label;
+    }
+    
+    public void setAxis(Table1D axis) {
+        this.axis = axis;
+        axis.setAxisParent(this);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " (2D)";// + axis;
+    }
+
+    @Override
+    public void populateCompareValues(Table otherTable) {
+        if(null == otherTable || !(otherTable instanceof Table2D)) {
+            return;
+        }
+
+        Table2D compareTable2D = (Table2D) otherTable;
+        if(data.length != compareTable2D.data.length ||
+                axis.data.length != compareTable2D.axis.data.length) {
+            return;
+        }
+
+        super.populateCompareValues(otherTable);
+        axis.populateCompareValues(compareTable2D.getAxis());
+    }
+
+    @Override
+    public void refreshCompare() {
+        populateCompareValues(getCompareTable());
+        axis.refreshCompare();
+    }
+
+    @Override
+    public StringBuffer getTableAsString() {
+        StringBuffer output = new StringBuffer(Settings.BLANK);
+        output.append(axis.getTableAsString());
+        output.append(Settings.NEW_LINE);
+        output.append(super.getTableAsString());
+        return output;
+    }
+
+    @Override
+    public Dimension getFrameSize() {
+        int height = verticalOverhead + cellHeight * 2;
+        int width = horizontalOverhead + data.length * cellWidth;
+        if (height < minHeight) {
+            height = minHeight;
+        }
+        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
+        if (width < minWidth) {
+            width = minWidth;
+        }
+        return new Dimension(width, height);
+    }
+
+    @Override
+    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+    	this.input = input;
+    	centerLayout.setRows(2);
+        centerLayout.setColumns(this.getDataSize());
+
+        try {
+            axis.populateTable(input, romRamOffset);
+            super.populateTable(input, romRamOffset);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+
+        // add to table
+        for (int i = 0; i < this.getDataSize(); i++) {
+            centerPanel.add(axis.getDataCell(i));
+        }
+        if (flip) {
+            for (int i = this.getDataSize() - 1; i >= 0; i--) {
+                centerPanel.add(this.getDataCell(i));
+            }
+        } else {
+            for (int i = 0; i < this.getDataSize(); i++) {
+                centerPanel.add(this.getDataCell(i));
+            }
+        }
+
+        if(null == axis.getName() || axis.getName().isEmpty() || Settings.BLANK == axis.getName()) {
+            ;// Do not add label.
+        } else if(null == axis.getCurrentScale() || "0x" == axis.getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            axisLabel = new JLabel(axis.getName(), JLabel.CENTER);
+            add(axisLabel, BorderLayout.NORTH);
+        } else {
+            axisLabel = new JLabel(axis.getName() + " (" + axis.getCurrentScale().getUnit() + ")", JLabel.CENTER);
+            add(axisLabel, BorderLayout.NORTH);
+        }
+
+        tableLabel = new JLabel(getCurrentScale().getUnit(), JLabel.CENTER);
+        add(tableLabel, BorderLayout.SOUTH);      
+        axisLabel.setBorder(new EmptyBorder(2, 4, 2, 4));   
+        
+        if(presetPanel != null) presetPanel.populatePanel();
+        repaint();
+    }
+
+    @Override
+    public void updateTableLabel() {
+        if(null == axis.getName() || axis.getName().length() < 1 || Settings.BLANK == axis.getName()) {
+            ;// Do not update label.
+        } else if(null == axis.getCurrentScale() || "0x" == axis.getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            axisLabel.setText(axis.getName());
+        } else {
+            axisLabel.setText(axis.getName() + " (" + axis.getCurrentScale().getUnit() + ")");
+        }
+
+        tableLabel.setText(getCurrentScale().getUnit());
+    }
+
+    @Override
+    public void clearSelection() {
+        axis.clearSelectedData();
+        clearSelectedData();
+    }
+
+    @Override
+    public void setRevertPoint() {
+        super.setRevertPoint();
+        axis.setRevertPoint();
+    }
+
+    @Override
+    public void undoAll() {
+        super.undoAll();
+        axis.undoAll();
+    }
+    
+
+    @Override
+    public byte[] saveFile(byte[] binData) {
+        /*
+        binData = super.saveFile(binData);
+        binData = axis.saveFile(binData);*/
+    	
+        return binData;
+    }
+
+    @Override
+    public void addKeyListener(KeyListener listener) {
+        super.addKeyListener(listener);
+        axis.addKeyListener(listener);
+    }
+
+    @Override
+    public void cursorUp() {
+        if (data[highlightY].isSelected()) {
+            axis.selectCellAt(highlightY);
+        }
+    }
+
+    @Override
+    public void drawTable() {
+        super.drawTable();
+        axis.drawTable();
+    }
+
+    @Override
+    public void cursorDown() {
+        axis.cursorDown();
+    }
+
+    @Override
+    public void cursorLeft() {
+        if (highlightY > 0 && data[highlightY].isSelected()) {
+            selectCellAt(highlightY - 1);
+        } else {
+            axis.cursorLeft();
+        }
+    }
+
+    @Override
+    public void cursorRight() {
+        if (highlightY < data.length - 1 && data[highlightY].isSelected()) {
+            selectCellAt(highlightY + 1);
+        } else {
+            axis.cursorRight();
+        }
+    }
+
+	@Override
+	public void shiftCursorUp() {
+        if (data[highlightY].isSelected()) {
+        	data[highlightY].setSelected(false);
+        }
+        axis.selectCellAt(highlightY);
+	}
+
+	@Override
+	public void shiftCursorDown() {
+        axis.cursorDown();
+	}
+
+	@Override
+	public void shiftCursorLeft() {
+        if (highlightY > 0 && data[highlightY].isSelected()) {
+        	selectCellAtWithoutClear(highlightY - 1);
+        } else {
+        	axis.shiftCursorLeft();
+        }
+	}
+
+	@Override
+	public void shiftCursorRight() {
+        if (highlightY < data.length - 1 && data[highlightY].isSelected()) {
+        	selectCellAtWithoutClear(highlightY + 1);
+        } else {
+        	axis.shiftCursorRight();
+        }
+	}
+
+    @Override
+    public void startHighlight(int x, int y) {
+        axis.clearSelectedData();
+        super.startHighlight(x, y);
+    }
+
+    @Override
+    public void copySelection() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        super.copySelection();
+        copySelection2DWorker = new CopySelection2DWorker(this);
+        copySelection2DWorker.execute();
+    }
+
+    @Override
+    public void copyTable() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        copyTable2DWorker = new CopyTable2DWorker(this);
+        copyTable2DWorker.execute();
+    }
+
+    @Override
+    public void paste() {
+        StringTokenizer st = new StringTokenizer(Settings.BLANK);
+        String input = Settings.BLANK;
+        try {
+            input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
+            st = new StringTokenizer(input, ST_DELIMITER);
+        } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
+        } catch (IOException ex) {
+        }
+
+        String pasteType = st.nextToken();
+
+        if (pasteType.equalsIgnoreCase("[Table2D]")) { // Paste table
+            String currentToken = st.nextToken(Settings.NEW_LINE);
+            if (currentToken.endsWith("\t")) {
+                currentToken = st.nextToken(Settings.NEW_LINE);
+            }
+
+            String axisValues = "[Table1D]" + Settings.NEW_LINE + currentToken;
+            String dataValues = "[Table1D]" + Settings.NEW_LINE + st.nextToken(Settings.NEW_LINE);
+
+            // put axis in clipboard and paste
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(axisValues), null);
+            axis.paste();
+            // put datavalues in clipboard and paste
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(dataValues), null);
+            super.paste();
+            // reset clipboard
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(input), null);
+
+        } else if (pasteType.equalsIgnoreCase("[Selection1D]")) { // paste selection
+            if (data[highlightY].isSelected()) {
+                super.paste();
+            } else {
+                axis.paste();
+            }
+        }
+    }
+
+    @Override
+    public void interpolate() {
+        super.interpolate();
+        this.getAxis().interpolate();
+    }
+
+    @Override
+    public void verticalInterpolate() {
+        super.verticalInterpolate();
+        this.getAxis().verticalInterpolate();
+    }
+
+    @Override
+    public void horizontalInterpolate() {
+        int[] coords = { getDataSize(), 0};
+        DataCellView[] tableData = getData();
+        DataCellView[] axisData = getAxis().getData();
+
+        for (int i = 0; i < getDataSize(); ++i) {
+            if (tableData[i].isSelected()) {
+                if (i < coords[0])
+                    coords[0] = i;
+                if (i > coords[1])
+                    coords[1] = i;
+            }
+        }
+        if (coords[1] - coords[0] > 1) {
+            double x, x1, x2, y1, y2;
+            x1 = axisData[coords[0]].getDataCell().getBinValue();
+            y1 = tableData[coords[0]].getDataCell().getBinValue();
+            x2 = axisData[coords[1]].getDataCell().getBinValue();
+            y2 = tableData[coords[1]].getDataCell().getBinValue();
+            for (int i = coords[0] + 1; i < coords[1]; ++i) {
+                x = axisData[i].getDataCell().getBinValue();
+                data[i].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
+            }
+        }
+        // Interpolate x axis in case the x axis in selected.
+        this.getAxis().horizontalInterpolate();
+    }
+
+    @Override
+    public boolean isLiveDataSupported() {
+        return !isNullOrEmpty(axis.getLogParam());
+    }
+
+    @Override
+    public boolean isButtonSelected() {
+        return true;
+    }
+
+    @Override
+    public void clearLiveDataTrace() {
+        super.clearLiveDataTrace();
+        axis.clearLiveDataTrace();
+    }
+
+    @Override
+    public void updateLiveDataHighlight() {
+        if (getOverlayLog()) {
+            data[axis.getPreviousLiveDataIndex()].setPreviousLiveDataTrace(true);
+            data[axis.getLiveDataIndex()].setPreviousLiveDataTrace(false);
+            data[axis.getLiveDataIndex()].setLiveDataTrace(true);
+        }
+    }
+
+    @Override
+    public String getLogParamString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(axis.getLogParamString()+ ", ");
+        sb.append(getName()+ ":" + getLogParam());
+        return sb.toString();
+    }
+
+    @Override
+    public void setOverlayLog(boolean overlayLog) {
+        super.setOverlayLog(overlayLog);
+        axis.setOverlayLog(overlayLog);
+    }
+
+    @Override
+    public void setCompareDisplay(Settings.CompareDisplay compareDisplay) {
+        super.setCompareDisplay(compareDisplay);
+        axis.setCompareDisplay(compareDisplay);
+    }
+
+    @Override
+    public void setCompareValueType(Settings.DataType compareValueType) {
+        super.setCompareValueType(compareValueType);
+        axis.setCompareValueType(compareValueType);
+    }
+
+    @Override
+    public void setCurrentScale(Scale curScale) {
+        if(SettingsManager.getSettings().isScaleHeadersAndData() && !axis.isStaticDataTable()) {
+            try {
+                this.axis.setScaleByName(curScale.getName());
+            } catch (NameNotFoundException e) {
+                try {
+                    this.axis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
+                } catch (NameNotFoundException e1) {
+                }
+            }
+        }
+        this.curScale = curScale;
+        updateTableLabel();
+        drawTable();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        try {
+            if(null == other) {
+                return false;
+            }
+
+            if(other == this) {
+                return true;
+            }
+
+            if(!(other instanceof Table2D)) {
+                return false;
+            }
+
+            Table2D otherTable = (Table2D)other;
+
+            if( (null == this.getName() && null == otherTable.getName())
+                    || (this.getName().isEmpty() && otherTable.getName().isEmpty()) ) {
+                ;// Skip name compare if name is null or empty.
+            } else if (!this.getName().equalsIgnoreCase(otherTable.getName())) {
+                return false;
+            }
+
+            if(!this.axis.equals(otherTable.axis)) {
+                return false;
+            }
+
+            if(this.data.length != otherTable.data.length)
+            {
+                return false;
+            }
+
+            if(this.data.equals(otherTable.data))
+            {
+                return true;
+            }
+
+            // Compare Bin Values
+            for(int i = 0 ; i < this.data.length ; i++) {
+                if(! this.data[i].equals(otherTable.data[i])) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch(Exception ex) {
+            // TODO: Log Exception.
+            return false;
+        }
+    }
+
+    @Override
+    public void repaint() {
+        super.repaint();
+        if(null != axis) {
+            axis.repaint();
+        }
+    }  
+}
+
+class CopySelection2DWorker extends SwingWorker<Void, Void> {
+    Table2D table;
+    Table extendedTable;
+
+    public CopySelection2DWorker(Table2D table)
+    {
+        this.table = table;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        table.getAxis().copySelection();
+        return null;
+    }
+
+    @Override
+    public void done() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(null);
+        }
+        table.setCursor(null);
+        ECUEditorManager.getECUEditor().setCursor(null);
+    }
+}
+
+class CopyTable2DWorker extends SwingWorker<Void, Void> {
+    Table2D table;
+
+    public CopyTable2DWorker(Table2D table)
+    {
+        this.table = table;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        String tableHeader = table.getSettings().getTable2DHeader();
+        StringBuffer output = new StringBuffer(tableHeader);
+        output.append(table.getTableAsString());
+
+        //copy to clipboard
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(output.toString()), null);
+        return null;
+
+    }
+
+    @Override
+    public void done() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(null);
+        }
+        table.setCursor(null);
+        ECUEditorManager.getECUEditor().setCursor(null);
+    }
+}

--- a/src/main/java/com/romraider/maps/Table2DView.java
+++ b/src/main/java/com/romraider/maps/Table2DView.java
@@ -302,7 +302,7 @@ public class Table2DView extends TableView {
         String input = Settings.BLANK;
         try {
             input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
-            st = new StringTokenizer(input, table.ST_DELIMITER);
+            st = new StringTokenizer(input, Table.ST_DELIMITER);
         } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
         } catch (IOException ex) {
         }
@@ -414,7 +414,7 @@ class CopyTable2DWorker extends SwingWorker<Void, Void> {
 
     @Override
     protected Void doInBackground() throws Exception {
-        String tableHeader = table.getSettings().getTable2DHeader();
+        String tableHeader = TableView.getSettings().getTable2DHeader();
         StringBuffer output = new StringBuffer(tableHeader);
         output.append(table.getTable().getTableAsString());
 

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -91,7 +91,6 @@ public class Table3D extends Table {
 
     public void setSizeX(int size) {
         data = new DataCell[size][data[0].length];
-       // centerLayout.setColumns(size + 1);
     }
 
     public int getSizeX() {
@@ -100,7 +99,6 @@ public class Table3D extends Table {
 
     public void setSizeY(int size) {
         data = new DataCell[data.length][size];
-        //centerLayout.setRows(size + 1);
     }
 
     public int getSizeY() {

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -328,7 +328,9 @@ public class Table3D extends Table {
                 }
             }
         }
-        this.curScale = curScale;
+        
+        this.curScale = curScale;     
+        if(tableView!=null) tableView.drawTable();
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -135,6 +135,8 @@ public class Table3D extends Table {
 
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws NullPointerException, ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+    	validateScaling();
+    	
     	// fill first empty cell
         if (!beforeRam) {
             this.ramOffset = romRamOffset;

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -30,8 +30,8 @@ public class Table3D extends Table {
 
     private static final long serialVersionUID = 3103448753263606599L;
 
-    private Table1D xAxis;
-    private Table1D yAxis;
+    private Table1D xAxis = new Table1D(TableType.X_AXIS);
+    private Table1D yAxis= new Table1D(TableType.Y_AXIS);;
 
     DataCell[][] data = new DataCell[1][1];
     private boolean swapXY = false;

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -30,8 +30,8 @@ public class Table3D extends Table {
 
     private static final long serialVersionUID = 3103448753263606599L;
 
-    private Table1D xAxis = new Table1D(TableType.X_AXIS);
-    private Table1D yAxis = new Table1D(TableType.Y_AXIS);
+    private Table1D xAxis;
+    private Table1D yAxis;
 
     DataCell[][] data = new DataCell[1][1];
     private boolean swapXY = false;
@@ -314,6 +314,7 @@ public class Table3D extends Table {
                     try {
                         this.xAxis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
                     } catch (NameNotFoundException e1) {
+                    	e1.printStackTrace();
                     }
                 }
             }
@@ -324,6 +325,7 @@ public class Table3D extends Table {
                     try {
                         this.yAxis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
                     } catch (NameNotFoundException e1) {
+                    	e1.printStackTrace();
                     }
                 }
             }

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -104,7 +104,24 @@ public class Table3D extends Table {
     public int getSizeY() {
         return data[0].length;
     }
-
+    
+    @Override
+    public void clearData() {
+        for(DataCell[] column : data) {
+            for(DataCell cell : column) {
+	    		cell.setTable(null);
+	    		cell.setRom(null);
+            }
+        }
+    	
+    	xAxis.clearData();
+    	yAxis.clearData();
+    	
+    	data = null;
+    	xAxis=null;
+    	yAxis=null;
+    }
+    
     @Override
     public StringBuffer getTableAsString() {
         StringBuffer output = new StringBuffer(Settings.BLANK);
@@ -134,12 +151,12 @@ public class Table3D extends Table {
     }
 
     @Override
-    public void populateTable(byte[] input, int romRamOffset) throws NullPointerException, ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+    public void populateTable(Rom rom) throws NullPointerException, ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
     	validateScaling();
     	
     	// fill first empty cell
         if (!beforeRam) {
-            this.ramOffset = romRamOffset;
+            this.ramOffset = rom.getRomID().getRamOffset();
         }
 
         // temporarily remove lock
@@ -148,8 +165,8 @@ public class Table3D extends Table {
 
         // populate axes
         try {
-            xAxis.populateTable(input, romRamOffset);
-            yAxis.populateTable(input, romRamOffset);
+            xAxis.populateTable(rom);
+            yAxis.populateTable(rom);
         } catch (ArrayIndexOutOfBoundsException ex) {
             throw new ArrayIndexOutOfBoundsException();
         }
@@ -168,7 +185,7 @@ public class Table3D extends Table {
                     x = y;
                     y = z;
                 }
-                DataCell c = new DataCell(this, offset, input);
+                DataCell c = new DataCell(this, offset, rom);
                 data[x][y] = c;
                 offset++;
             }

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -23,6 +23,7 @@ import static com.romraider.util.ParamChecker.isNullOrEmpty;
 
 import javax.naming.NameNotFoundException;
 import com.romraider.Settings;
+import com.romraider.util.NumberUtil;
 import com.romraider.util.SettingsManager;
 
 public class Table3D extends Table {
@@ -41,7 +42,11 @@ public class Table3D extends Table {
     public TableType getType() {
         return Table.TableType.TABLE_3D;
     }
-
+    
+    public Table3DView getTableView() {
+    	return (Table3DView) tableView;
+    }
+    
     public Table1D getXAxis() {
         return xAxis;
     }
@@ -102,6 +107,33 @@ public class Table3D extends Table {
         return data[0].length;
     }
 
+    @Override
+    public StringBuffer getTableAsString() {
+        StringBuffer output = new StringBuffer(Settings.BLANK);
+
+        output.append(xAxis.getTableAsString());
+        output.append(Settings.NEW_LINE);
+
+        for (int y = 0; y < getSizeY(); y++) {
+            output.append(NumberUtil.stringValue(yAxis.data[y].getRealValue()));
+            output.append(Settings.TAB);
+
+            for (int x = 0; x < getSizeX(); x++) {
+
+            	output.append(NumberUtil.stringValue(data[x][y].getRealValue()));
+                
+                if (x < getSizeX() - 1) {
+                    output.append(Settings.TAB);
+                }
+            }
+
+            if (y < getSizeY() - 1) {
+                output.append(Settings.NEW_LINE);
+            }
+        }
+
+        return output;
+    }
 
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws NullPointerException, ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -21,59 +21,21 @@ package com.romraider.maps;
 
 import static com.romraider.util.ParamChecker.isNullOrEmpty;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Cursor;
-import java.awt.Dimension;
-import java.awt.GridLayout;
-import java.awt.Toolkit;
-import java.awt.Window;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.event.KeyListener;
-import java.io.IOException;
-import java.text.MessageFormat;
-import java.util.ResourceBundle;
-import java.util.StringTokenizer;
-
 import javax.naming.NameNotFoundException;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
-import javax.swing.SwingWorker;
-import javax.swing.border.EmptyBorder;
-
 import com.romraider.Settings;
-import com.romraider.editor.ecu.ECUEditorManager;
-import com.romraider.logger.ecu.ui.swing.vertical.VerticalLabelUI;
-import com.romraider.util.NumberUtil;
-import com.romraider.util.ResourceUtil;
 import com.romraider.util.SettingsManager;
 
 public class Table3D extends Table {
 
     private static final long serialVersionUID = 3103448753263606599L;
-    private static final ResourceBundle rb = new ResourceUtil().getBundle(
-            Table3D.class.getName());
+
     private Table1D xAxis = new Table1D(TableType.X_AXIS);
     private Table1D yAxis = new Table1D(TableType.Y_AXIS);
-    private JLabel xAxisLabel;
-    private JLabel yAxisLabel;
 
-    DataCellView[][] data = new DataCellView[1][1];
+    DataCell[][] data = new DataCell[1][1];
     private boolean swapXY = false;
     private boolean flipX = false;
     private boolean flipY = false;
-
-    CopyTable3DWorker copyTable3DWorker;
-    CopySelection3DWorker copySelection3DWorker;
-
-    public Table3D() {
-        verticalOverhead += 39;
-        horizontalOverhead += 10;
-    }
 
     @Override
     public TableType getType() {
@@ -123,8 +85,8 @@ public class Table3D extends Table {
     }
 
     public void setSizeX(int size) {
-        data = new DataCellView[size][data[0].length];
-        centerLayout.setColumns(size + 1);
+        data = new DataCell[size][data[0].length];
+       // centerLayout.setColumns(size + 1);
     }
 
     public int getSizeX() {
@@ -132,32 +94,18 @@ public class Table3D extends Table {
     }
 
     public void setSizeY(int size) {
-        data = new DataCellView[data.length][size];
-        centerLayout.setRows(size + 1);
+        data = new DataCell[data.length][size];
+        //centerLayout.setRows(size + 1);
     }
 
     public int getSizeY() {
         return data[0].length;
     }
 
-    @Override
-    public void drawTable() {
-        for(DataCellView[] column : data) {
-            for(DataCellView cell : column) {
-                if(null != cell) {
-                    cell.drawCell();
-                }
-            }
-        }
-        xAxis.drawTable();
-        yAxis.drawTable();
-    }
 
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws NullPointerException, ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
-    	this.input = input;
     	// fill first empty cell
-        centerPanel.add(new JLabel());
         if (!beforeRam) {
             this.ramOffset = romRamOffset;
         }
@@ -174,10 +122,6 @@ public class Table3D extends Table {
             throw new ArrayIndexOutOfBoundsException();
         }
 
-        for (int x = 0; x < xAxis.getDataSize(); x++) {
-            centerPanel.add(xAxis.getDataCell(x));
-        }
-
         int offset = 0;
 
         int iMax = swapXY ? xAxis.getDataSize() : yAxis.getDataSize();
@@ -192,112 +136,37 @@ public class Table3D extends Table {
                     x = y;
                     y = z;
                 }
-
-                // show locked cell
-                if (tempLock) {
-                    data[x][y].setForeground(Color.GRAY);
-                }
-                
-                DataCell c = new DataCell(this, offset);
-                data[x][y] = new DataCellView(c,x,y);
+                DataCell c = new DataCell(this, offset, input);
+                data[x][y] = c;
                 offset++;
             }
         }
 
-        for (int y = 0; y < yAxis.getDataSize(); y++) {
-            centerPanel.add(yAxis.getDataCell(y));
-            for (int x = 0; x < xAxis.getDataSize(); x++) {
-                centerPanel.add(data[x][y]);
-            }
-        }
-
         // reset locked status
-        locked = tempLock;
-
-        GridLayout topLayout = new GridLayout(2, 1);
-        JPanel topPanel = new JPanel(topLayout);
-        this.add(topPanel, BorderLayout.NORTH);
-        topPanel.add(new JLabel(getName(), JLabel.CENTER), BorderLayout.NORTH);
-
-        if(null == xAxis.getName() || xAxis.getName().length() < 1 || Settings.BLANK == xAxis.getName()) {
-            ;// Do not add label.
-        } else if(null == xAxis.getCurrentScale() || "0x" == xAxis.getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            xAxisLabel = new JLabel(xAxis.getName(), JLabel.CENTER);
-            topPanel.add(xAxisLabel, BorderLayout.NORTH);
-        } else {
-            xAxisLabel = new JLabel(xAxis.getName() + " (" + xAxis.getCurrentScale().getUnit() + ")", JLabel.CENTER);
-            topPanel.add(xAxisLabel, BorderLayout.NORTH);
-        }
-
-        yAxisLabel = null;
-        if(null == yAxis.getName() || yAxis.getName().length() < 1 || Settings.BLANK == yAxis.getName()) {
-            ;// Do not add label.
-        } else if(null == yAxis.getCurrentScale() || "0x" == yAxis.getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            yAxisLabel = new JLabel(yAxis.getName());
-        } else {
-            yAxisLabel = new JLabel(yAxis.getName() + " (" + yAxis.getCurrentScale().getUnit() + ")");
-        }
-
-        yAxisLabel.setUI(new VerticalLabelUI(false));
-        add(yAxisLabel, BorderLayout.WEST);
-
-        tableLabel = new JLabel(getCurrentScale().getUnit(), JLabel.CENTER);
-        add(tableLabel, BorderLayout.SOUTH);
-        
-        yAxisLabel.setBorder(new EmptyBorder(2, 4, 2, 4));  
-        
-        if(xAxisLabel!=null)
-        	xAxisLabel.setBorder(new EmptyBorder(2, 4, 2, 4)); 
-        
-        if(presetPanel != null) presetPanel.populatePanel();
+        locked = tempLock;      
         calcCellRanges();
     }
 
     @Override
-    public void updateTableLabel() {
-        if(null == xAxis.getName() || xAxis.getName().length() < 1 || Settings.BLANK == xAxis.getName()) {
-            ;// Do not update label.
-        } else if(null == xAxis.getCurrentScale() || "0x" == xAxis.getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            xAxisLabel.setText(xAxis.getName());
-        } else {
-            xAxisLabel.setText(xAxis.getName() + " (" + xAxis.getCurrentScale().getUnit() + ")");
-        }
-
-        if(null == yAxis.getName() || yAxis.getName().length() < 1 || Settings.BLANK == yAxis.getName()) {
-            ;// Do not update label.
-        } else if(null == yAxis.getCurrentScale() || "0x" == yAxis.getCurrentScale().getUnit()) {
-            // static or no scale exists.
-            yAxisLabel.setText(yAxis.getName());
-        } else {
-            yAxisLabel.setText(yAxis.getName() + " (" + yAxis.getCurrentScale().getUnit() + ")");
-        }
-
-        tableLabel.setText(getCurrentScale().getUnit());
-    }
-
-    @Override
     public void calcCellRanges() {
-        double binMax = data[0][0].getDataCell().getBinValue();
-        double binMin = data[0][0].getDataCell().getBinValue();
+        double binMax = data[0][0].getBinValue();
+        double binMin = data[0][0].getBinValue();
 
-        double compareMax = data[0][0].getDataCell().getCompareValue();
-        double compareMin = data[0][0].getDataCell().getCompareValue();
+        double compareMax = data[0][0].getCompareValue();
+        double compareMin = data[0][0].getCompareValue();
 
-        for(DataCellView[] column : data) {
-            for(DataCellView cell : column) {
+        for(DataCell[] column : data) {
+            for(DataCell cell : column) {
                 // Calc bin
-                if(binMax < cell.getDataCell().getBinValue()) {
-                    binMax = cell.getDataCell().getBinValue();
+                if(binMax < cell.getBinValue()) {
+                    binMax = cell.getBinValue();
                 }
-                if(binMin > cell.getDataCell().getBinValue()) {
-                    binMin = cell.getDataCell().getBinValue();
+                if(binMin > cell.getBinValue()) {
+                    binMin = cell.getBinValue();
                 }
 
                 // Calc compare
-                double compareValue = cell.getDataCell().getCompareValue();
+                double compareValue = cell.getCompareValue();
                 if(compareMax < compareValue) {
                     compareMax = compareValue;
                 }
@@ -310,37 +179,6 @@ public class Table3D extends Table {
         setMinBin(binMin);
         setMaxCompare(compareMax);
         setMinCompare(compareMin);
-    }
-
-    @Override
-    public StringBuffer getTableAsString() {
-        StringBuffer output = new StringBuffer(Settings.BLANK);
-
-        output.append(xAxis.getTableAsString());
-        output.append(Settings.NEW_LINE);
-
-        for (int y = 0; y < getSizeY(); y++) {
-            output.append(NumberUtil.stringValue(yAxis.data[y].getDataCell().getRealValue()));
-            output.append(Settings.TAB);
-
-            for (int x = 0; x < getSizeX(); x++) {
-                if (overlayLog) {
-                    output.append(data[x][y].getCellText());
-                }
-                else {
-                    output.append(NumberUtil.stringValue(data[x][y].getDataCell().getRealValue()));
-                }
-                if (x < getSizeX() - 1) {
-                    output.append(Settings.TAB);
-                }
-            }
-
-            if (y < getSizeY() - 1) {
-                output.append(Settings.NEW_LINE);
-            }
-        }
-
-        return output;
     }
 
     @Override
@@ -357,13 +195,11 @@ public class Table3D extends Table {
             return;
         }
 
-        clearLiveDataTrace();
-
         int x=0;
-        for (DataCellView[] column : data) {
+        for (DataCell[] column : data) {
             int y = 0;
-            for(DataCellView cell : column) {
-                cell.getDataCell().setCompareValue(compareTable3D.data[x][y].getDataCell());
+            for(DataCell cell : column) {
+                cell.setCompareValue(compareTable3D.data[x][y]);
                 y++;
             }
             x++;
@@ -373,7 +209,6 @@ public class Table3D extends Table {
         yAxis.populateCompareValues(compareTable3D.getYAxis());
 
         calcCellRanges();
-        drawTable();
     }
 
     @Override
@@ -383,115 +218,19 @@ public class Table3D extends Table {
         yAxis.refreshCompare();
     }
 
-    @Override
-    public Dimension getFrameSize() {
-        int height = verticalOverhead + cellHeight * data[0].length;
-        int width = horizontalOverhead + data.length * cellWidth;
-        if (height < minHeight) {
-            height = minHeight;
-        }
-        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
-        if (width < minWidth) {
-            width = minWidth;
-        }
-        return new Dimension(width, height);
-    }
 
     @Override
     public String toString() {
-        return super.toString() + " (3D)";/* +
-                "\n   Flip X: " + flipX +
-                "\n   Size X: " + data.length +
-                "\n   Flip Y: " + flipY +
-                "\n   Size Y: " + data[0].length +
-                "\n   Swap X/Y: " + swapXY +
-                xAxis +
-                yAxis;*/
+        return super.toString() + " (3D)";
     }
 
-    @Override
-    public void increment(double increment) {
-        if (!locked) {
-            for (int x = 0; x < this.getSizeX(); x++) {
-                for (int y = 0; y < this.getSizeY(); y++) {
-                    if (data[x][y].isSelected()) {
-                        data[x][y].getDataCell().increment(increment);
-                    }
-                }
-            }
-        }
-    }
-
-    @Override
-    public void multiply(double factor) {
-        if (!locked) {
-            for (int x = 0; x < this.getSizeX(); x++) {
-                for (int y = 0; y < this.getSizeY(); y++) {
-                    if (data[x][y].isSelected()) {
-                    	
-                    	if(getCurrentScale().getName().equals("Raw Value"))
-                    		data[x][y].getDataCell().multiplyRaw(factor);                	
-                    	else 
-                    		data[x][y].getDataCell().multiply(factor);                            
-                    }
-                }
-            }
-        }
-    }
-
-    @Override
-    public void clearSelection() {
-        xAxis.clearSelectedData();
-        yAxis.clearSelectedData();
-        clearSelectedData();
-    }
-
-    @Override
-    public void clearSelectedData() {
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
-                data[x][y].setSelected(false);
-            }
-        }
-    }
-
-    @Override
-    public void highlight(int xCoord, int yCoord) {
-        if (highlight) {
-            for (int x = 0; x < this.getSizeX(); x++) {
-                for (int y = 0; y < this.getSizeY(); y++) {
-                    if (((y >= highlightY && y <= yCoord) ||
-                            (y <= highlightY && y >= yCoord)) &&
-                            ((x >= highlightX && x <= xCoord) ||
-                                    (x <= highlightX && x >= xCoord))) {
-                        data[x][y].setHighlighted(true);
-                    } else {
-                        data[x][y].setHighlighted(false);
-                    }
-                }
-            }
-        }
-    }
-
-    @Override
-    public void stopHighlight() {
-        highlight = false;
-        // loop through, selected and un-highlight
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
-                if (data[x][y].isHighlighted()) {
-                    data[x][y].setSelected(true);
-                    data[x][y].setHighlighted(false);
-                }
-            }
-        }
-    }
+    
 
     @Override
     public void setRevertPoint() {
         for (int x = 0; x < this.getSizeX(); x++) {
             for (int y = 0; y < this.getSizeY(); y++) {
-                data[x][y].getDataCell().setRevertPoint();
+                data[x][y].setRevertPoint();
             }
         }
         yAxis.setRevertPoint();
@@ -499,11 +238,10 @@ public class Table3D extends Table {
     }
 
     @Override
-    public void undoAll() {
-        clearLiveDataTrace();
+    public void undoAll() throws UserLevelException {
         for (int x = 0; x < this.getSizeX(); x++) {
             for (int y = 0; y < this.getSizeY(); y++) {
-                data[x][y].getDataCell().undo();
+                data[x][y].undo();
             }
         }
         yAxis.undoAll();
@@ -511,369 +249,8 @@ public class Table3D extends Table {
     }
 
     @Override
-    public void undoSelected() {
-        clearLiveDataTrace();
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
-                if (data[x][y].isSelected()) {
-                    data[x][y].getDataCell().undo();
-                }
-            }
-        }
-    }
-
-
-    @Override
     public byte[] saveFile(byte[] binData) {
     	return binData;
-    }
-
-    @Override
-    public void setRealValue(String realValue) {
-        if (!locked && !(userLevel > getSettings().getUserLevel()) ) {
-            for(DataCellView[] column : data) {
-                for(DataCellView cell : column) {
-                    if(cell.isSelected()) {
-                        cell.getDataCell().setRealValue(realValue);
-                    }
-                }
-            }
-        } else if (userLevel > getSettings().getUserLevel()) {
-            JOptionPane.showMessageDialog(this, MessageFormat.format(
-                    rb.getString("USERLVLTOLOW"), userLevel),
-                    rb.getString("TBLNOTMODIFY"),
-                    JOptionPane.INFORMATION_MESSAGE);
-        }
-        xAxis.setRealValue(realValue);
-        yAxis.setRealValue(realValue);
-    }
-
-    @Override
-    public void addKeyListener(KeyListener listener) {
-        xAxis.addKeyListener(listener);
-        yAxis.addKeyListener(listener);
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
-                data[x][y].addKeyListener(listener);
-            }
-        }
-    }
-
-    public void selectCellAt(int y, Table1D axisType) {
-        if (axisType.getType() == Table.TableType.Y_AXIS) {
-            selectCellAt(0, y);
-        } else { // y axis
-            selectCellAt(y, 0);
-        }
-        ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(this);
-    }
-
-    public void deSelectCellAt(int x, int y) {
-        clearSelection();
-        data[x][y].setSelected(false);
-        highlightX = x;
-        highlightY = y;
-    }
-
-    public void selectCellAt(int x, int y) {
-        clearSelection();
-        data[x][y].setSelected(true);
-        highlightX = x;
-        highlightY = y;
-    }
-
-    public void selectCellAtWithoutClear(int x, int y) {
-        data[x][y].setSelected(true);
-        highlightX = x;
-        highlightY = y;
-    }
-
-    @Override
-    public void cursorUp() {
-        if (highlightY > 0 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX, highlightY - 1);
-        } else if (data[highlightX][highlightY].isSelected()) {
-            xAxis.selectCellAt(highlightX);
-        } else {
-            xAxis.cursorUp();
-            yAxis.cursorUp();
-        }
-    }
-
-    @Override
-    public void cursorDown() {
-        if (highlightY < getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX, highlightY + 1);
-        } else {
-            xAxis.cursorDown();
-            yAxis.cursorDown();
-        }
-    }
-
-    @Override
-    public void cursorLeft() {
-        if (highlightX > 0 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX - 1, highlightY);
-        } else if (data[highlightX][highlightY].isSelected()) {
-            yAxis.selectCellAt(highlightY);
-        } else {
-            xAxis.cursorLeft();
-            yAxis.cursorLeft();
-        }
-    }
-
-    @Override
-    public void cursorRight() {
-        if (highlightX < getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX + 1, highlightY);
-        } else {
-            xAxis.cursorRight();
-            yAxis.cursorRight();
-        }
-    }
-
-	@Override
-	public void shiftCursorUp() {
-        if (highlightY > 0 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX, highlightY - 1);
-        } else if (data[highlightX][highlightY].isSelected()) {
-        	data[highlightX][highlightY].setSelected(false);
-        	xAxis.selectCellAt(highlightX);
-        } else {
-        	xAxis.cursorUp();
-        	yAxis.shiftCursorUp();
-        }
-	}
-
-	@Override
-	public void shiftCursorDown() {
-        if (highlightY < getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX, highlightY + 1);
-        } else {
-            xAxis.shiftCursorDown();
-            yAxis.shiftCursorDown();
-        }
-	}
-
-	@Override
-	public void shiftCursorLeft() {
-        if (highlightX > 0 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX - 1, highlightY);
-        } else if (data[highlightX][highlightY].isSelected()) {
-            yAxis.selectCellAt(highlightY);
-        } else {
-            xAxis.shiftCursorLeft();
-            yAxis.shiftCursorLeft();
-        }
-	}
-
-	@Override
-	public void shiftCursorRight() {
-        if (highlightX < getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX + 1, highlightY);
-        } else {
-            xAxis.shiftCursorRight();
-            yAxis.shiftCursorRight();
-        }
-	}
-
-    @Override
-    public void startHighlight(int x, int y) {
-        xAxis.clearSelectedData();
-        yAxis.clearSelectedData();
-        super.startHighlight(x, y);
-    }
-
-    @Override
-    public void copySelection() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        }
-        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        copySelection3DWorker = new CopySelection3DWorker(this);
-        copySelection3DWorker.execute();
-
-    }
-
-    @Override
-    public void copyTable() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        }
-        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        copyTable3DWorker = new CopyTable3DWorker(this);
-        copyTable3DWorker.execute();
-    }
-
-    @Override
-    public void paste() {
-        StringTokenizer st = new StringTokenizer(Settings.BLANK);
-        String input = Settings.BLANK;
-        try {
-            input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
-            st = new StringTokenizer(input, ST_DELIMITER);
-        } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
-        } catch (IOException ex) {
-        }
-
-        String pasteType = st.nextToken();
-
-        if ("[Table3D]".equalsIgnoreCase(pasteType)) { // Paste table
-            String currentToken = st.nextToken(Settings.NEW_LINE);
-            if (currentToken.endsWith("\t")) {
-                currentToken = st.nextToken(Settings.NEW_LINE);
-            }
-            String xAxisValues = "[Table1D]" + Settings.NEW_LINE + currentToken;
-
-            // build y axis and data values
-            StringBuffer yAxisValues = new StringBuffer("[Table1D]" + Settings.NEW_LINE + st.nextToken("\t"));
-            StringBuffer dataValues = new StringBuffer("[Table3D]" + Settings.NEW_LINE + st.nextToken("\t") + st.nextToken(Settings.NEW_LINE));
-            while (st.hasMoreTokens()) {
-                yAxisValues.append("\t").append(st.nextToken("\t"));
-                dataValues.append(Settings.NEW_LINE).append(st.nextToken("\t")).append(st.nextToken(Settings.NEW_LINE));
-            }
-
-            // put x axis in clipboard and paste
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(xAxisValues), null);
-            xAxis.paste();
-            // put y axis in clipboard and paste
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(yAxisValues)), null);
-            yAxis.paste();
-            // put datavalues in clipboard and paste
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(dataValues)), null);
-            pasteValues();
-            // reset clipboard
-            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(input), null);
-
-        } else if ("[Selection3D]".equalsIgnoreCase(pasteType)) { // paste selection
-            pasteValues();
-        } else if ("[Selection1D]".equalsIgnoreCase(pasteType)) { // paste selection
-            xAxis.paste();
-            yAxis.paste();
-        }
-    }
-
-    public void pasteValues() {
-        StringTokenizer st = new StringTokenizer(Settings.BLANK);
-        try {
-            String input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
-            st = new StringTokenizer(input, ST_DELIMITER);
-        } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
-        } catch (IOException ex) {
-        }
-
-        String pasteType = st.nextToken();
-
-        // figure paste start cell
-        int startX = 0;
-        int startY = 0;
-        // if pasting a table, startX and Y at 0, else highlight is start
-        if ("[Selection3D]".equalsIgnoreCase(pasteType)) {
-            startX = highlightX;
-            startY = highlightY;
-        }
-
-        // set values
-        for (int y = startY; st.hasMoreTokens() && y < getSizeY(); y++) {
-            String checkToken = st.nextToken(Settings.NEW_LINE);
-            if (y==startY && checkToken.endsWith("\t")) {
-                checkToken = st.nextToken(Settings.NEW_LINE);
-            }
-            StringTokenizer currentLine = new StringTokenizer(checkToken, ST_DELIMITER);
-            for (int x = startX; currentLine.hasMoreTokens() && x < getSizeX(); x++) {
-                String currentToken = currentLine.nextToken();
-
-                try {
-                    if (!data[x][y].getText().equalsIgnoreCase(currentToken)) {
-                        data[x][y].getDataCell().setRealValue(currentToken);
-                    }
-                } catch (ArrayIndexOutOfBoundsException ex) { /* copied table is larger than current table*/ }
-            }
-        }
-    }
-
-    @Override
-    public void verticalInterpolate() {
-        int[] coords = { getSizeX(), getSizeY(), 0, 0};
-        DataCellView[][] tableData = get3dData();
-        DataCellView[] axisData = getYAxis().getData();
-        int i, j;
-        for (i = 0; i < getSizeX(); ++i) {
-            for (j = 0; j < getSizeY(); ++j) {
-                if (tableData[i][j].isSelected()) {
-                    if (i < coords[0])
-                        coords[0] = i;
-                    if (i > coords[2])
-                        coords[2] = i;
-                    if (j < coords[1])
-                        coords[1] = j;
-                    if (j > coords[3])
-                        coords[3] = j;
-                }
-            }
-        }
-        if (coords[3] - coords[1] > 1) {
-            double x, x1, x2, y1, y2;
-            x1 = axisData[coords[1]].getDataCell().getBinValue();
-            x2 = axisData[coords[3]].getDataCell().getBinValue();
-            for (i = coords[0]; i <= coords[2]; ++i) {
-                y1 = tableData[i][coords[1]].getDataCell().getBinValue();
-                y2 = tableData[i][coords[3]].getDataCell().getBinValue();
-                for (j = coords[1] + 1; j < coords[3]; ++j) {
-                    x = axisData[j].getDataCell().getBinValue();
-                    tableData[i][j].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
-                }
-            }
-        }
-        // Interpolate y axis in case the y axis in selected.
-        this.getYAxis().verticalInterpolate();
-    }
-
-    @Override
-    public void horizontalInterpolate() {
-        int[] coords = { getSizeX(), getSizeY(), 0, 0 };
-        DataCellView[][] tableData = get3dData();
-        DataCellView[] axisData = getXAxis().getData();
-        int i, j;
-        for (i = 0; i < getSizeX(); ++i) {
-            for (j = 0; j < getSizeY(); ++j) {
-                if (tableData[i][j].isSelected()) {
-                    if (i < coords[0])
-                        coords[0] = i;
-                    if (i > coords[2])
-                        coords[2] = i;
-                    if (j < coords[1])
-                        coords[1] = j;
-                    if (j > coords[3])
-                        coords[3] = j;
-                }
-            }
-        }
-        if (coords[2] - coords[0] > 1) {
-            double x, x1, x2, y1, y2;
-            x1 = axisData[coords[0]].getDataCell().getBinValue();
-            x2 = axisData[coords[2]].getDataCell().getBinValue();
-            for (i = coords[1]; i <= coords[3]; ++i) {
-                y1 = tableData[coords[0]][i].getDataCell().getBinValue();
-                y2 = tableData[coords[2]][i].getDataCell().getBinValue();
-                for (j = coords[0] + 1; j < coords[2]; ++j) {
-                    x = axisData[j].getDataCell().getBinValue();
-                    tableData[j][i].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
-                }
-            }
-        }
-        // Interpolate x axis in case the x axis in selected.
-        this.getXAxis().horizontalInterpolate();
-    }
-
-    @Override
-    public void interpolate() {
-        verticalInterpolate();
-        horizontalInterpolate();
     }
 
     @Override
@@ -886,52 +263,8 @@ public class Table3D extends Table {
         return true;
     }
 
-    @Override
-    public void highlightLiveData(String liveValue) {
-        if (getOverlayLog()) {
-            int x = xAxis.getLiveDataIndex();
-            int y = yAxis.getLiveDataIndex();
-            DataCellView cell = data[x][y];
-            cell.setLiveDataTrace(true);
-            cell.getDataCell().setLiveDataTraceValue(liveValue);
-            getToolbar().setLiveDataValue(liveValue);
-        }
-    }
-
-    @Override
-    public void updateLiveDataHighlight() {
-        if (getOverlayLog()) {
-            int x = xAxis.getLiveDataIndex();
-            int y = yAxis.getLiveDataIndex();
-            int xp = xAxis.getPreviousLiveDataIndex();
-            int yp = yAxis.getPreviousLiveDataIndex();
-            data[xp][yp].setPreviousLiveDataTrace(true);
-            data[x][y].setPreviousLiveDataTrace(false);
-            data[x][y].setLiveDataTrace(true);
-        }
-    }
-
-    @Override
-    public void clearLiveDataTrace() {
-        xAxis.clearLiveDataTrace();
-        yAxis.clearLiveDataTrace();
-        for (int x = 0; x < getSizeX(); x++) {
-            for (int y = 0; y < getSizeY(); y++) {
-                data[x][y].setLiveDataTrace(false);
-                data[x][y].setPreviousLiveDataTrace(false);
-            }
-        }
-    }
-
-    public DataCellView[][] get3dData() {
+    public DataCell[][] get3dData() {
         return data;
-    }
-
-    @Override
-    public void setCompareDisplay(Settings.CompareDisplay compareDisplay) {
-        super.setCompareDisplay(compareDisplay);
-        xAxis.setCompareDisplay(compareDisplay);
-        yAxis.setCompareDisplay(compareDisplay);
     }
 
     @Override
@@ -966,8 +299,6 @@ public class Table3D extends Table {
             }
         }
         this.curScale = curScale;
-        updateTableLabel();
-        drawTable();
     }
 
     @Override
@@ -977,13 +308,6 @@ public class Table3D extends Table {
         sb.append(yAxis.getLogParamString()+", ");
         sb.append(getName()+ ":" + getLogParam());
         return sb.toString();
-    }
-
-    @Override
-    public void setOverlayLog(boolean overlayLog) {
-        super.setOverlayLog(overlayLog);
-        xAxis.setOverlayLog(overlayLog);
-        yAxis.setOverlayLog(overlayLog);
     }
 
     @Override
@@ -1043,122 +367,6 @@ public class Table3D extends Table {
             return false;
         }
     }
-
-    @Override
-    public void repaint() {
-        super.repaint();
-
-        if(null != xAxis) {
-            xAxis.repaint();
-        }
-
-        if(null != yAxis) {
-            yAxis.repaint();
-        }
-    }
 }
 
-class CopySelection3DWorker extends SwingWorker<Void, Void> {
-    Table3D table;
 
-    public CopySelection3DWorker(Table3D table)
-    {
-        this.table = table;
-    }
-
-    @Override
-    protected Void doInBackground() throws Exception {
-        // find bounds of selection
-        // coords[0] = x min, y min, x max, y max
-        boolean copy = false;
-        int[] coords = new int[4];
-        coords[0] = table.getSizeX();
-        coords[1] = table.getSizeY();
-
-        for (int x = 0; x < table.getSizeX(); x++) {
-            for (int y = 0; y < table.getSizeY(); y++) {
-                if (table.get3dData()[x][y].isSelected()) {
-                    if (x < coords[0]) {
-                        coords[0] = x;
-                        copy = true;
-                    }
-                    if (x > coords[2]) {
-                        coords[2] = x;
-                        copy = true;
-                    }
-                    if (y < coords[1]) {
-                        coords[1] = y;
-                        copy = true;
-                    }
-                    if (y > coords[3]) {
-                        coords[3] = y;
-                        copy = true;
-                    }
-                }
-            }
-        }
-        // make string of selection
-        if (copy) {
-            StringBuffer output = new StringBuffer("[Selection3D]" + Settings.NEW_LINE);
-            for (int y = coords[1]; y <= coords[3]; y++) {
-                for (int x = coords[0]; x <= coords[2]; x++) {
-                    if (table.get3dData()[x][y].isSelected()) {
-                        output.append(NumberUtil.stringValue(table.get3dData()[x][y].getDataCell().getRealValue()));
-                    } else {
-                        output.append("x"); // x represents non-selected cell
-                    }
-                    if (x < coords[2]) {
-                        output.append("\t");
-                    }
-                }
-                if (y < coords[3]) {
-                    output.append(Settings.NEW_LINE);
-                }
-                //copy to clipboard
-                Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
-            }
-        } else {
-            table.getXAxis().copySelection();
-            table.getYAxis().copySelection();
-        }
-        return null;
-    }
-
-    @Override
-    public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
-        if(null != ancestorWindow) {
-            ancestorWindow.setCursor(null);
-        }
-        table.setCursor(null);
-        ECUEditorManager.getECUEditor().setCursor(null);
-    }
-}
-
-class CopyTable3DWorker extends SwingWorker<Void, Void> {
-    Table3D table;
-
-    public CopyTable3DWorker(Table3D table)
-    {
-        this.table = table;
-    }
-
-    @Override
-    protected Void doInBackground() throws Exception {
-        String tableHeader = table.getSettings().getTable3DHeader();
-        StringBuffer output = new StringBuffer(tableHeader);
-        output.append(table.getTableAsString());
-        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
-        return null;
-    }
-
-    @Override
-    public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
-        if(null != ancestorWindow){
-            ancestorWindow.setCursor(null);
-        }
-        table.setCursor(null);
-        ECUEditorManager.getECUEditor().setCursor(null);
-    }
-}

--- a/src/main/java/com/romraider/maps/Table3DView.java
+++ b/src/main/java/com/romraider/maps/Table3DView.java
@@ -52,7 +52,7 @@ import com.romraider.util.NumberUtil;
 import com.romraider.util.ResourceUtil;
 import com.romraider.util.SettingsManager;
 
-public class Table3D extends Table {
+public class Table3DView extends TableView {
 
     private static final long serialVersionUID = 3103448753263606599L;
     private static final ResourceBundle rb = new ResourceUtil().getBundle(

--- a/src/main/java/com/romraider/maps/Table3DView.java
+++ b/src/main/java/com/romraider/maps/Table3DView.java
@@ -85,7 +85,7 @@ public class Table3DView extends TableView {
 	        for(DataCellView[] column : data) {
 	            for(DataCellView cell : column) {
 	                if(null != cell) {
-	                    cell.repaint();
+	                    cell.drawCell();
 	                }
 	            }
 	        }
@@ -95,34 +95,26 @@ public class Table3DView extends TableView {
     		xAxis.drawTable();
     	
     	if(yAxis!=null)
-        yAxis.drawTable();
+    		yAxis.drawTable();
     }
 
     @Override
+    //TODO
     public void populateTableVisual() {
     	// fill first empty cell
         centerPanel.add(new JLabel());
-        centerLayout.setColumns(xAxis.getTable().getDataSize());
-        centerLayout.setRows(yAxis.getTable().getDataSize());
+        centerLayout.setColumns(table.getSizeX()+1);
+        centerLayout.setRows(table.getSizeY()+1);
         
         // temporarily remove lock
         boolean tempLock = table.locked;
         table.locked = false;
-
-        // populate axes
-        try {
-            xAxis.populateTableVisual();
-            yAxis.populateTableVisual();
-        } catch (ArrayIndexOutOfBoundsException ex) {
-            throw new ArrayIndexOutOfBoundsException();
-        }
-
+            
         for (int x = 0; x < xAxis.getTable().getDataSize(); x++) {
             centerPanel.add(xAxis.getDataCell(x));
         }
 
-        
-        data = new DataCellView[xAxis.getTable().getDataSize()][yAxis.getTable().getDataSize()];
+        data = new DataCellView[table.getSizeX()][table.getSizeY()];
         
         int iMax = table.getSwapXY() ? xAxis.getTable().getDataSize() : yAxis.getTable().getDataSize();
         int jMax = table.getSwapXY() ? yAxis.getTable().getDataSize() : xAxis.getTable().getDataSize();
@@ -141,8 +133,7 @@ public class Table3DView extends TableView {
                 if (tempLock) {
                     data[x][y].setForeground(Color.GRAY);
                 }
-                
-             
+                            
                 data[x][y] = new DataCellView(table.get3dData()[x][y], this, x,y);
             }
         }
@@ -153,7 +144,7 @@ public class Table3DView extends TableView {
                 centerPanel.add(data[x][y]);
             }
         }
-
+        
         // reset locked status
         table.locked = tempLock;
 
@@ -196,6 +187,7 @@ public class Table3DView extends TableView {
         	xAxisLabel.setBorder(new EmptyBorder(2, 4, 2, 4)); 
         
         if(presetPanel != null) presetPanel.populatePanel();
+        drawTable();
     }
 
     @Override

--- a/src/main/java/com/romraider/maps/Table3DView.java
+++ b/src/main/java/com/romraider/maps/Table3DView.java
@@ -55,89 +55,30 @@ import com.romraider.util.SettingsManager;
 public class Table3DView extends TableView {
 
     private static final long serialVersionUID = 3103448753263606599L;
-    private static final ResourceBundle rb = new ResourceUtil().getBundle(
-            Table3D.class.getName());
-    private Table1D xAxis = new Table1D(TableType.X_AXIS);
-    private Table1D yAxis = new Table1D(TableType.Y_AXIS);
+    private static final ResourceBundle rb = new ResourceUtil().getBundle(Table3D.class.getName());
+    private Table3D table;
+    private Table1DView xAxis;
+    private Table1DView yAxis;
     private JLabel xAxisLabel;
     private JLabel yAxisLabel;
 
     DataCellView[][] data = new DataCellView[1][1];
-    private boolean swapXY = false;
-    private boolean flipX = false;
-    private boolean flipY = false;
 
     CopyTable3DWorker copyTable3DWorker;
     CopySelection3DWorker copySelection3DWorker;
 
-    public Table3D() {
+    public Table3DView(Table3D table) {
+    	super(table);
+    	xAxis = new Table1DView(table.getXAxis());
+    	yAxis = new Table1DView(table.getYAxis());
+    	
         verticalOverhead += 39;
         horizontalOverhead += 10;
     }
-
+    
     @Override
-    public TableType getType() {
-        return Table.TableType.TABLE_3D;
-    }
-
-    public Table1D getXAxis() {
-        return xAxis;
-    }
-
-    public void setXAxis(Table1D xAxis) {
-        this.xAxis = xAxis;
-        xAxis.setAxisParent(this);
-    }
-
-    public Table1D getYAxis() {
-        return yAxis;
-    }
-
-    public void setYAxis(Table1D yAxis) {
-        this.yAxis = yAxis;
-        yAxis.setAxisParent(this);
-    }
-
-    public boolean getSwapXY() {
-        return swapXY;
-    }
-
-    public void setSwapXY(boolean swapXY) {
-        this.swapXY = swapXY;
-    }
-
-    public boolean getFlipX() {
-        return flipX;
-    }
-
-    public void setFlipX(boolean flipX) {
-        this.flipX = flipX;
-    }
-
-    public boolean getFlipY() {
-        return flipY;
-    }
-
-    public void setFlipY(boolean flipY) {
-        this.flipY = flipY;
-    }
-
-    public void setSizeX(int size) {
-        data = new DataCellView[size][data[0].length];
-        centerLayout.setColumns(size + 1);
-    }
-
-    public int getSizeX() {
-        return data.length;
-    }
-
-    public void setSizeY(int size) {
-        data = new DataCellView[data.length][size];
-        centerLayout.setRows(size + 1);
-    }
-
-    public int getSizeY() {
-        return data[0].length;
+    public Table3D getTable() {
+    	return table;
     }
 
     @Override
@@ -155,16 +96,12 @@ public class Table3DView extends TableView {
 
     @Override
     public void populateTable(byte[] input, int romRamOffset) throws NullPointerException, ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
-    	this.input = input;
     	// fill first empty cell
         centerPanel.add(new JLabel());
-        if (!beforeRam) {
-            this.ramOffset = romRamOffset;
-        }
-
+        /*
         // temporarily remove lock
-        boolean tempLock = locked;
-        locked = false;
+        boolean tempLock = table.locked;
+        table.locked = false;
 
         // populate axes
         try {
@@ -174,14 +111,14 @@ public class Table3DView extends TableView {
             throw new ArrayIndexOutOfBoundsException();
         }
 
-        for (int x = 0; x < xAxis.getDataSize(); x++) {
+        for (int x = 0; x < xAxis.getTable().getDataSize(); x++) {
             centerPanel.add(xAxis.getDataCell(x));
         }
 
         int offset = 0;
 
-        int iMax = swapXY ? xAxis.getDataSize() : yAxis.getDataSize();
-        int jMax = swapXY ? yAxis.getDataSize() : xAxis.getDataSize();
+        int iMax = swapXY ? xAxis.getTable().getDataSize() : yAxis.getTable().getDataSize();
+        int jMax = swapXY ? yAxis.getTable().getDataSize() : xAxis.getTable().getDataSize();
         for (int i = 0; i < iMax; i++) {
             for (int j = 0; j < jMax; j++) {
 
@@ -251,67 +188,33 @@ public class Table3DView extends TableView {
         if(xAxisLabel!=null)
         	xAxisLabel.setBorder(new EmptyBorder(2, 4, 2, 4)); 
         
-        if(presetPanel != null) presetPanel.populatePanel();
-        calcCellRanges();
+        if(presetPanel != null) presetPanel.populatePanel();*/
     }
 
     @Override
     public void updateTableLabel() {
         if(null == xAxis.getName() || xAxis.getName().length() < 1 || Settings.BLANK == xAxis.getName()) {
             ;// Do not update label.
-        } else if(null == xAxis.getCurrentScale() || "0x" == xAxis.getCurrentScale().getUnit()) {
+        } else if(null == xAxis.getTable().getCurrentScale() || "0x" == xAxis.getTable().getCurrentScale().getUnit()) {
             // static or no scale exists.
             xAxisLabel.setText(xAxis.getName());
         } else {
-            xAxisLabel.setText(xAxis.getName() + " (" + xAxis.getCurrentScale().getUnit() + ")");
+            xAxisLabel.setText(xAxis.getName() + " (" + xAxis.getTable().getCurrentScale().getUnit() + ")");
         }
 
         if(null == yAxis.getName() || yAxis.getName().length() < 1 || Settings.BLANK == yAxis.getName()) {
             ;// Do not update label.
-        } else if(null == yAxis.getCurrentScale() || "0x" == yAxis.getCurrentScale().getUnit()) {
+        } else if(null == yAxis.getTable().getCurrentScale() || "0x" == yAxis.getTable().getCurrentScale().getUnit()) {
             // static or no scale exists.
             yAxisLabel.setText(yAxis.getName());
         } else {
-            yAxisLabel.setText(yAxis.getName() + " (" + yAxis.getCurrentScale().getUnit() + ")");
+            yAxisLabel.setText(yAxis.getName() + " (" + yAxis.getTable().getCurrentScale().getUnit() + ")");
         }
 
-        tableLabel.setText(getCurrentScale().getUnit());
+        tableLabel.setText(table.getCurrentScale().getUnit());
     }
 
-    @Override
-    public void calcCellRanges() {
-        double binMax = data[0][0].getDataCell().getBinValue();
-        double binMin = data[0][0].getDataCell().getBinValue();
-
-        double compareMax = data[0][0].getDataCell().getCompareValue();
-        double compareMin = data[0][0].getDataCell().getCompareValue();
-
-        for(DataCellView[] column : data) {
-            for(DataCellView cell : column) {
-                // Calc bin
-                if(binMax < cell.getDataCell().getBinValue()) {
-                    binMax = cell.getDataCell().getBinValue();
-                }
-                if(binMin > cell.getDataCell().getBinValue()) {
-                    binMin = cell.getDataCell().getBinValue();
-                }
-
-                // Calc compare
-                double compareValue = cell.getDataCell().getCompareValue();
-                if(compareMax < compareValue) {
-                    compareMax = compareValue;
-                }
-                if(compareMin > compareValue) {
-                    compareMin = compareValue;
-                }
-            }
-        }
-        setMaxBin(binMax);
-        setMinBin(binMin);
-        setMaxCompare(compareMax);
-        setMinCompare(compareMin);
-    }
-
+  
     @Override
     public StringBuffer getTableAsString() {
         StringBuffer output = new StringBuffer(Settings.BLANK);
@@ -319,68 +222,28 @@ public class Table3DView extends TableView {
         output.append(xAxis.getTableAsString());
         output.append(Settings.NEW_LINE);
 
-        for (int y = 0; y < getSizeY(); y++) {
+        for (int y = 0; y < table.getSizeY(); y++) {
             output.append(NumberUtil.stringValue(yAxis.data[y].getDataCell().getRealValue()));
             output.append(Settings.TAB);
 
-            for (int x = 0; x < getSizeX(); x++) {
+            for (int x = 0; x < table.getSizeX(); x++) {
                 if (overlayLog) {
                     output.append(data[x][y].getCellText());
                 }
                 else {
                     output.append(NumberUtil.stringValue(data[x][y].getDataCell().getRealValue()));
                 }
-                if (x < getSizeX() - 1) {
+                if (x < table.getSizeX() - 1) {
                     output.append(Settings.TAB);
                 }
             }
 
-            if (y < getSizeY() - 1) {
+            if (y < table.getSizeY() - 1) {
                 output.append(Settings.NEW_LINE);
             }
         }
 
         return output;
-    }
-
-    @Override
-    public void populateCompareValues(Table otherTable) {
-        if(null == otherTable || !(otherTable instanceof Table3D)) {
-            return;
-        }
-
-        Table3D compareTable3D = (Table3D) otherTable;
-        if(data.length != compareTable3D.data.length ||
-                data[0].length != compareTable3D.data[0].length ||
-                xAxis.getDataSize() != compareTable3D.xAxis.getDataSize() ||
-                yAxis.getDataSize() != compareTable3D.yAxis.getDataSize()) {
-            return;
-        }
-
-        clearLiveDataTrace();
-
-        int x=0;
-        for (DataCellView[] column : data) {
-            int y = 0;
-            for(DataCellView cell : column) {
-                cell.getDataCell().setCompareValue(compareTable3D.data[x][y].getDataCell());
-                y++;
-            }
-            x++;
-        }
-
-        xAxis.populateCompareValues(compareTable3D.getXAxis());
-        yAxis.populateCompareValues(compareTable3D.getYAxis());
-
-        calcCellRanges();
-        drawTable();
-    }
-
-    @Override
-    public void refreshCompare() {
-        populateCompareValues(getCompareTable());
-        xAxis.refreshCompare();
-        yAxis.refreshCompare();
     }
 
     @Override
@@ -390,7 +253,7 @@ public class Table3DView extends TableView {
         if (height < minHeight) {
             height = minHeight;
         }
-        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
+        int minWidth = table.isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
         if (width < minWidth) {
             width = minWidth;
         }
@@ -410,46 +273,34 @@ public class Table3DView extends TableView {
     }
 
     @Override
-    public void increment(double increment) {
-        if (!locked) {
-            for (int x = 0; x < this.getSizeX(); x++) {
-                for (int y = 0; y < this.getSizeY(); y++) {
+    public void increment(double increment) throws UserLevelException {
+            for (int x = 0; x < table.getSizeX(); x++) {
+                for (int y = 0; y < table.getSizeY(); y++) {
                     if (data[x][y].isSelected()) {
                         data[x][y].getDataCell().increment(increment);
                     }
                 }
             }
-        }
     }
 
     @Override
-    public void multiply(double factor) {
-        if (!locked) {
-            for (int x = 0; x < this.getSizeX(); x++) {
-                for (int y = 0; y < this.getSizeY(); y++) {
-                    if (data[x][y].isSelected()) {
-                    	
-                    	if(getCurrentScale().getName().equals("Raw Value"))
-                    		data[x][y].getDataCell().multiplyRaw(factor);                	
-                    	else 
+    public void multiply(double factor) throws UserLevelException {
+            for (int x = 0; x < table.getSizeX(); x++) {
+                for (int y = 0; y < table.getSizeY(); y++) {
+                    if (data[x][y].isSelected()) {                    
                     		data[x][y].getDataCell().multiply(factor);                            
                     }
                 }
-            }
-        }
+            }        
     }
 
     @Override
     public void clearSelection() {
-        xAxis.clearSelectedData();
-        yAxis.clearSelectedData();
-        clearSelectedData();
-    }
-
-    @Override
-    public void clearSelectedData() {
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
+        xAxis.clearSelection();
+        yAxis.clearSelection();
+        
+        for (int x = 0; x < table.getSizeX(); x++) {
+            for (int y = 0; y < table.getSizeY(); y++) {
                 data[x][y].setSelected(false);
             }
         }
@@ -458,8 +309,8 @@ public class Table3DView extends TableView {
     @Override
     public void highlight(int xCoord, int yCoord) {
         if (highlight) {
-            for (int x = 0; x < this.getSizeX(); x++) {
-                for (int y = 0; y < this.getSizeY(); y++) {
+            for (int x = 0; x < table.getSizeX(); x++) {
+                for (int y = 0; y < table.getSizeY(); y++) {
                     if (((y >= highlightY && y <= yCoord) ||
                             (y <= highlightY && y >= yCoord)) &&
                             ((x >= highlightX && x <= xCoord) ||
@@ -477,8 +328,8 @@ public class Table3DView extends TableView {
     public void stopHighlight() {
         highlight = false;
         // loop through, selected and un-highlight
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
+        for (int x = 0; x < table.getSizeX(); x++) {
+            for (int y = 0; y < table.getSizeY(); y++) {
                 if (data[x][y].isHighlighted()) {
                     data[x][y].setSelected(true);
                     data[x][y].setHighlighted(false);
@@ -488,33 +339,10 @@ public class Table3DView extends TableView {
     }
 
     @Override
-    public void setRevertPoint() {
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
-                data[x][y].getDataCell().setRevertPoint();
-            }
-        }
-        yAxis.setRevertPoint();
-        xAxis.setRevertPoint();
-    }
-
-    @Override
-    public void undoAll() {
+    public void undoSelected() throws UserLevelException {
         clearLiveDataTrace();
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
-                data[x][y].getDataCell().undo();
-            }
-        }
-        yAxis.undoAll();
-        xAxis.undoAll();
-    }
-
-    @Override
-    public void undoSelected() {
-        clearLiveDataTrace();
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
+        for (int x = 0; x < table.getSizeX(); x++) {
+            for (int y = 0; y < table.getSizeY(); y++) {
                 if (data[x][y].isSelected()) {
                     data[x][y].getDataCell().undo();
                 }
@@ -522,28 +350,16 @@ public class Table3DView extends TableView {
         }
     }
 
-
     @Override
-    public byte[] saveFile(byte[] binData) {
-    	return binData;
-    }
-
-    @Override
-    public void setRealValue(String realValue) {
-        if (!locked && !(userLevel > getSettings().getUserLevel()) ) {
-            for(DataCellView[] column : data) {
-                for(DataCellView cell : column) {
-                    if(cell.isSelected()) {
-                        cell.getDataCell().setRealValue(realValue);
-                    }
+    public void setRealValue(String realValue) throws UserLevelException {
+        for(DataCellView[] column : data) {
+            for(DataCellView cell : column) {
+                if(cell.isSelected()) {
+                    cell.getDataCell().setRealValue(realValue);
                 }
             }
-        } else if (userLevel > getSettings().getUserLevel()) {
-            JOptionPane.showMessageDialog(this, MessageFormat.format(
-                    rb.getString("USERLVLTOLOW"), userLevel),
-                    rb.getString("TBLNOTMODIFY"),
-                    JOptionPane.INFORMATION_MESSAGE);
         }
+
         xAxis.setRealValue(realValue);
         yAxis.setRealValue(realValue);
     }
@@ -552,8 +368,8 @@ public class Table3DView extends TableView {
     public void addKeyListener(KeyListener listener) {
         xAxis.addKeyListener(listener);
         yAxis.addKeyListener(listener);
-        for (int x = 0; x < this.getSizeX(); x++) {
-            for (int y = 0; y < this.getSizeY(); y++) {
+        for (int x = 0; x < table.getSizeX(); x++) {
+            for (int y = 0; y < table.getSizeY(); y++) {
                 data[x][y].addKeyListener(listener);
             }
         }
@@ -565,7 +381,7 @@ public class Table3DView extends TableView {
         } else { // y axis
             selectCellAt(y, 0);
         }
-        ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(this);
+        ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
     }
 
     public void deSelectCellAt(int x, int y) {
@@ -602,7 +418,7 @@ public class Table3DView extends TableView {
 
     @Override
     public void cursorDown() {
-        if (highlightY < getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
+        if (highlightY < table.getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
             selectCellAt(highlightX, highlightY + 1);
         } else {
             xAxis.cursorDown();
@@ -624,7 +440,7 @@ public class Table3DView extends TableView {
 
     @Override
     public void cursorRight() {
-        if (highlightX < getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
+        if (highlightX < table.getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
             selectCellAt(highlightX + 1, highlightY);
         } else {
             xAxis.cursorRight();
@@ -647,7 +463,7 @@ public class Table3DView extends TableView {
 
 	@Override
 	public void shiftCursorDown() {
-        if (highlightY < getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
+        if (highlightY < table.getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
         	selectCellAtWithoutClear(highlightX, highlightY + 1);
         } else {
             xAxis.shiftCursorDown();
@@ -669,7 +485,7 @@ public class Table3DView extends TableView {
 
 	@Override
 	public void shiftCursorRight() {
-        if (highlightX < getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
+        if (highlightX < table.getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
         	selectCellAtWithoutClear(highlightX + 1, highlightY);
         } else {
             xAxis.shiftCursorRight();
@@ -679,8 +495,8 @@ public class Table3DView extends TableView {
 
     @Override
     public void startHighlight(int x, int y) {
-        xAxis.clearSelectedData();
-        yAxis.clearSelectedData();
+        xAxis.clearSelection();
+        yAxis.clearSelection();
         super.startHighlight(x, y);
     }
 
@@ -710,12 +526,12 @@ public class Table3DView extends TableView {
     }
 
     @Override
-    public void paste() {
+    public void paste() throws UserLevelException {
         StringTokenizer st = new StringTokenizer(Settings.BLANK);
         String input = Settings.BLANK;
         try {
             input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
-            st = new StringTokenizer(input, ST_DELIMITER);
+            st = new StringTokenizer(input, Table.ST_DELIMITER);
         } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
         } catch (IOException ex) {
         }
@@ -757,11 +573,11 @@ public class Table3DView extends TableView {
         }
     }
 
-    public void pasteValues() {
+    public void pasteValues() throws UserLevelException {
         StringTokenizer st = new StringTokenizer(Settings.BLANK);
         try {
             String input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
-            st = new StringTokenizer(input, ST_DELIMITER);
+            st = new StringTokenizer(input, Table.ST_DELIMITER);
         } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
         } catch (IOException ex) {
         }
@@ -778,13 +594,13 @@ public class Table3DView extends TableView {
         }
 
         // set values
-        for (int y = startY; st.hasMoreTokens() && y < getSizeY(); y++) {
+        for (int y = startY; st.hasMoreTokens() && y < table.getSizeY(); y++) {
             String checkToken = st.nextToken(Settings.NEW_LINE);
             if (y==startY && checkToken.endsWith("\t")) {
                 checkToken = st.nextToken(Settings.NEW_LINE);
             }
-            StringTokenizer currentLine = new StringTokenizer(checkToken, ST_DELIMITER);
-            for (int x = startX; currentLine.hasMoreTokens() && x < getSizeX(); x++) {
+            StringTokenizer currentLine = new StringTokenizer(checkToken, Table.ST_DELIMITER);
+            for (int x = startX; currentLine.hasMoreTokens() && x < table.getSizeX(); x++) {
                 String currentToken = currentLine.nextToken();
 
                 try {
@@ -797,13 +613,13 @@ public class Table3DView extends TableView {
     }
 
     @Override
-    public void verticalInterpolate() {
-        int[] coords = { getSizeX(), getSizeY(), 0, 0};
+    public void verticalInterpolate() throws UserLevelException {
+        int[] coords = { table.getSizeX(), table.getSizeY(), 0, 0};
         DataCellView[][] tableData = get3dData();
-        DataCellView[] axisData = getYAxis().getData();
+        DataCellView[] axisData = table.getYAxis().getTableView().getData();
         int i, j;
-        for (i = 0; i < getSizeX(); ++i) {
-            for (j = 0; j < getSizeY(); ++j) {
+        for (i = 0; i < table.getSizeX(); ++i) {
+            for (j = 0; j < table.getSizeY(); ++j) {
                 if (tableData[i][j].isSelected()) {
                     if (i < coords[0])
                         coords[0] = i;
@@ -830,17 +646,17 @@ public class Table3DView extends TableView {
             }
         }
         // Interpolate y axis in case the y axis in selected.
-        this.getYAxis().verticalInterpolate();
+        table.getYAxis().getTableView().verticalInterpolate();
     }
 
     @Override
-    public void horizontalInterpolate() {
-        int[] coords = { getSizeX(), getSizeY(), 0, 0 };
+    public void horizontalInterpolate() throws UserLevelException {
+        int[] coords = { table.getSizeX(), table.getSizeY(), 0, 0 };
         DataCellView[][] tableData = get3dData();
-        DataCellView[] axisData = getXAxis().getData();
+        DataCellView[] axisData = table.getXAxis().getTableView().getData();
         int i, j;
-        for (i = 0; i < getSizeX(); ++i) {
-            for (j = 0; j < getSizeY(); ++j) {
+        for (i = 0; i < table.getSizeX(); ++i) {
+            for (j = 0; j < table.getSizeY(); ++j) {
                 if (tableData[i][j].isSelected()) {
                     if (i < coords[0])
                         coords[0] = i;
@@ -867,23 +683,13 @@ public class Table3DView extends TableView {
             }
         }
         // Interpolate x axis in case the x axis in selected.
-        this.getXAxis().horizontalInterpolate();
+        table.getXAxis().getTableView().horizontalInterpolate();
     }
 
     @Override
-    public void interpolate() {
+    public void interpolate() throws UserLevelException {
         verticalInterpolate();
         horizontalInterpolate();
-    }
-
-    @Override
-    public boolean isLiveDataSupported() {
-        return !isNullOrEmpty(xAxis.getLogParam()) && !isNullOrEmpty(yAxis.getLogParam());
-    }
-
-    @Override
-    public boolean isButtonSelected() {
-        return true;
     }
 
     @Override
@@ -915,8 +721,8 @@ public class Table3DView extends TableView {
     public void clearLiveDataTrace() {
         xAxis.clearLiveDataTrace();
         yAxis.clearLiveDataTrace();
-        for (int x = 0; x < getSizeX(); x++) {
-            for (int y = 0; y < getSizeY(); y++) {
+        for (int x = 0; x < table.getSizeX(); x++) {
+            for (int y = 0; y < table.getSizeY(); y++) {
                 data[x][y].setLiveDataTrace(false);
                 data[x][y].setPreviousLiveDataTrace(false);
             }
@@ -935,51 +741,6 @@ public class Table3DView extends TableView {
     }
 
     @Override
-    public void setCompareValueType(Settings.DataType compareValueType) {
-        super.setCompareValueType(compareValueType);
-        xAxis.setCompareValueType(compareValueType);
-        yAxis.setCompareValueType(compareValueType);
-    }
-
-    @Override
-    public void setCurrentScale(Scale curScale) {
-        if(SettingsManager.getSettings().isScaleHeadersAndData()) {
-            if(!xAxis.isStaticDataTable()) {
-                try {
-                    this.xAxis.setScaleByName(curScale.getName());
-                } catch (NameNotFoundException e) {
-                    try {
-                        this.xAxis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
-                    } catch (NameNotFoundException e1) {
-                    }
-                }
-            }
-            if(!yAxis.isStaticDataTable()) {
-                try {
-                    this.yAxis.setScaleByName(curScale.getName());
-                } catch (NameNotFoundException e) {
-                    try {
-                        this.yAxis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
-                    } catch (NameNotFoundException e1) {
-                    }
-                }
-            }
-        }
-        this.curScale = curScale;
-        updateTableLabel();
-        drawTable();
-    }
-
-    @Override
-    public String getLogParamString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(xAxis.getLogParamString()+", ");
-        sb.append(yAxis.getLogParamString()+", ");
-        sb.append(getName()+ ":" + getLogParam());
-        return sb.toString();
-    }
-
-    @Override
     public void setOverlayLog(boolean overlayLog) {
         super.setOverlayLog(overlayLog);
         xAxis.setOverlayLog(overlayLog);
@@ -988,60 +749,7 @@ public class Table3DView extends TableView {
 
     @Override
     public boolean equals(Object other) {
-        try {
-            if(null == other) {
-                return false;
-            }
-
-            if(other == this) {
-                return true;
-            }
-
-            if(!(other instanceof Table3D)) {
-                return false;
-            }
-
-            Table3D otherTable = (Table3D)other;
-
-            if( (null == this.getName() && null == otherTable.getName())
-                    || (this.getName().isEmpty() && otherTable.getName().isEmpty()) ) {
-                ;// Skip name compare if name is null or empty.
-            } else if(!this.getName().equalsIgnoreCase(otherTable.getName())) {
-                return false;
-            }
-
-            if(! this.xAxis.equals(otherTable.xAxis)) {
-                return false;
-            }
-
-            if(! this.yAxis.equals(otherTable.yAxis)) {
-                return false;
-            }
-
-            if(this.data.length != otherTable.data.length || this.data[0].length != otherTable.data[0].length)
-            {
-                return false;
-            }
-
-            if(this.data.equals(otherTable.data))
-            {
-                return true;
-            }
-
-            // Compare Bin Values
-            for(int i = 0 ; i < this.data.length ; i++) {
-                for(int j = 0; j < this.data[i].length ; j++) {
-                    if(! this.data[i][j].equals(otherTable.data[i][j]) ) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        } catch(Exception ex) {
-            // TODO: Log Exception.
-            return false;
-        }
+       return table.equals(other);
     }
 
     @Override
@@ -1059,11 +767,11 @@ public class Table3DView extends TableView {
 }
 
 class CopySelection3DWorker extends SwingWorker<Void, Void> {
-    Table3D table;
+    Table3DView tableView;
 
-    public CopySelection3DWorker(Table3D table)
+    public CopySelection3DWorker(Table3DView table)
     {
-        this.table = table;
+        this.tableView = table;
     }
 
     @Override
@@ -1072,12 +780,12 @@ class CopySelection3DWorker extends SwingWorker<Void, Void> {
         // coords[0] = x min, y min, x max, y max
         boolean copy = false;
         int[] coords = new int[4];
-        coords[0] = table.getSizeX();
-        coords[1] = table.getSizeY();
+        coords[0] = tableView.getTable().getSizeX();
+        coords[1] = tableView.getTable().getSizeY();
 
-        for (int x = 0; x < table.getSizeX(); x++) {
-            for (int y = 0; y < table.getSizeY(); y++) {
-                if (table.get3dData()[x][y].isSelected()) {
+        for (int x = 0; x < tableView.getTable().getSizeX(); x++) {
+            for (int y = 0; y < tableView.getTable().getSizeY(); y++) {
+                if (tableView.get3dData()[x][y].isSelected()) {
                     if (x < coords[0]) {
                         coords[0] = x;
                         copy = true;
@@ -1102,8 +810,8 @@ class CopySelection3DWorker extends SwingWorker<Void, Void> {
             StringBuffer output = new StringBuffer("[Selection3D]" + Settings.NEW_LINE);
             for (int y = coords[1]; y <= coords[3]; y++) {
                 for (int x = coords[0]; x <= coords[2]; x++) {
-                    if (table.get3dData()[x][y].isSelected()) {
-                        output.append(NumberUtil.stringValue(table.get3dData()[x][y].getDataCell().getRealValue()));
+                    if (tableView.get3dData()[x][y].isSelected()) {
+                        output.append(NumberUtil.stringValue(tableView.get3dData()[x][y].getDataCell().getRealValue()));
                     } else {
                         output.append("x"); // x represents non-selected cell
                     }
@@ -1118,47 +826,47 @@ class CopySelection3DWorker extends SwingWorker<Void, Void> {
                 Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
             }
         } else {
-            table.getXAxis().copySelection();
-            table.getYAxis().copySelection();
+            tableView.getTable().getXAxis().getTableView().copySelection();
+            tableView.getTable().getYAxis().getTableView().copySelection();
         }
         return null;
     }
 
     @Override
     public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(tableView);
         if(null != ancestorWindow) {
             ancestorWindow.setCursor(null);
         }
-        table.setCursor(null);
+        tableView.setCursor(null);
         ECUEditorManager.getECUEditor().setCursor(null);
     }
 }
 
 class CopyTable3DWorker extends SwingWorker<Void, Void> {
-    Table3D table;
+    Table3DView tableView;
 
-    public CopyTable3DWorker(Table3D table)
+    public CopyTable3DWorker(Table3DView v)
     {
-        this.table = table;
+        this.tableView = v;
     }
 
     @Override
     protected Void doInBackground() throws Exception {
-        String tableHeader = table.getSettings().getTable3DHeader();
+        String tableHeader = TableView.getSettings().getTable3DHeader();
         StringBuffer output = new StringBuffer(tableHeader);
-        output.append(table.getTableAsString());
+        output.append(tableView.getTableAsString());
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
         return null;
     }
 
     @Override
     public void done() {
-        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(tableView);
         if(null != ancestorWindow){
             ancestorWindow.setCursor(null);
         }
-        table.setCursor(null);
+        tableView.setCursor(null);
         ECUEditorManager.getECUEditor().setCursor(null);
     }
 }

--- a/src/main/java/com/romraider/maps/Table3DView.java
+++ b/src/main/java/com/romraider/maps/Table3DView.java
@@ -237,39 +237,6 @@ public class Table3DView extends TableView {
                 yAxis;*/
     }
 
-    @Override
-    public void increment(double increment) throws UserLevelException {
-            for (int x = 0; x < table.getSizeX(); x++) {
-                for (int y = 0; y < table.getSizeY(); y++) {
-                    if (data[x][y].isSelected()) {
-                        data[x][y].getDataCell().increment(increment);
-                    }
-                }
-            }
-    }
-
-    @Override
-    public void multiply(double factor) throws UserLevelException {
-            for (int x = 0; x < table.getSizeX(); x++) {
-                for (int y = 0; y < table.getSizeY(); y++) {
-                    if (data[x][y].isSelected()) {                    
-                    		data[x][y].getDataCell().multiply(factor);                            
-                    }
-                }
-            }        
-    }
-
-    @Override
-    public void clearSelection() {
-        xAxis.clearSelection();
-        yAxis.clearSelection();
-        
-        for (int x = 0; x < table.getSizeX(); x++) {
-            for (int y = 0; y < table.getSizeY(); y++) {
-                data[x][y].setSelected(false);
-            }
-        }
-    }
 
     @Override
     public void highlight(int xCoord, int yCoord) {
@@ -296,7 +263,7 @@ public class Table3DView extends TableView {
         for (int x = 0; x < table.getSizeX(); x++) {
             for (int y = 0; y < table.getSizeY(); y++) {
                 if (data[x][y].isHighlighted()) {
-                    data[x][y].setSelected(true);
+                    data[x][y].getDataCell().setSelected(true);
                     data[x][y].setHighlighted(false);
                 }
             }
@@ -316,20 +283,6 @@ public class Table3DView extends TableView {
     }
 
     @Override
-    public void setRealValue(String realValue) throws UserLevelException {
-        for(DataCellView[] column : data) {
-            for(DataCellView cell : column) {
-                if(cell.isSelected()) {
-                    cell.getDataCell().setRealValue(realValue);
-                }
-            }
-        }
-
-        xAxis.setRealValue(realValue);
-        yAxis.setRealValue(realValue);
-    }
-
-    @Override
     public void addKeyListener(KeyListener listener) {
         xAxis.addKeyListener(listener);
         yAxis.addKeyListener(listener);
@@ -342,39 +295,19 @@ public class Table3DView extends TableView {
 
     public void selectCellAt(int y, Table1D axisType) {
         if (axisType.getType() == Table.TableType.Y_AXIS) {
-            selectCellAt(0, y);
+            table.selectCellAt(0, y);
         } else { // y axis
-            selectCellAt(y, 0);
+            table.selectCellAt(y, 0);
         }
         ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
-    }
-
-    public void deSelectCellAt(int x, int y) {
-        clearSelection();
-        data[x][y].setSelected(false);
-        highlightX = x;
-        highlightY = y;
-    }
-
-    public void selectCellAt(int x, int y) {
-        clearSelection();
-        data[x][y].setSelected(true);
-        highlightX = x;
-        highlightY = y;
-    }
-
-    public void selectCellAtWithoutClear(int x, int y) {
-        data[x][y].setSelected(true);
-        highlightX = x;
-        highlightY = y;
     }
 
     @Override
     public void cursorUp() {
         if (highlightY > 0 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX, highlightY - 1);
+            table.selectCellAt(highlightX, highlightY - 1);
         } else if (data[highlightX][highlightY].isSelected()) {
-            xAxis.selectCellAt(highlightX);
+            xAxis.getTable().selectCellAt(highlightX);
         } else {
             xAxis.cursorUp();
             yAxis.cursorUp();
@@ -384,7 +317,7 @@ public class Table3DView extends TableView {
     @Override
     public void cursorDown() {
         if (highlightY < table.getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX, highlightY + 1);
+            table.selectCellAt(highlightX, highlightY + 1);
         } else {
             xAxis.cursorDown();
             yAxis.cursorDown();
@@ -394,9 +327,9 @@ public class Table3DView extends TableView {
     @Override
     public void cursorLeft() {
         if (highlightX > 0 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX - 1, highlightY);
+            table.selectCellAt(highlightX - 1, highlightY);
         } else if (data[highlightX][highlightY].isSelected()) {
-            yAxis.selectCellAt(highlightY);
+            yAxis.getTable().selectCellAt(highlightY);
         } else {
             xAxis.cursorLeft();
             yAxis.cursorLeft();
@@ -406,7 +339,7 @@ public class Table3DView extends TableView {
     @Override
     public void cursorRight() {
         if (highlightX < table.getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
-            selectCellAt(highlightX + 1, highlightY);
+            table.selectCellAt(highlightX + 1, highlightY);
         } else {
             xAxis.cursorRight();
             yAxis.cursorRight();
@@ -416,10 +349,10 @@ public class Table3DView extends TableView {
 	@Override
 	public void shiftCursorUp() {
         if (highlightY > 0 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX, highlightY - 1);
+        	table.selectCellAtWithoutClear(highlightX, highlightY - 1);
         } else if (data[highlightX][highlightY].isSelected()) {
-        	data[highlightX][highlightY].setSelected(false);
-        	xAxis.selectCellAt(highlightX);
+        	data[highlightX][highlightY].getDataCell().setSelected(false);
+        	xAxis.getTable().selectCellAt(highlightX);
         } else {
         	xAxis.cursorUp();
         	yAxis.shiftCursorUp();
@@ -429,7 +362,7 @@ public class Table3DView extends TableView {
 	@Override
 	public void shiftCursorDown() {
         if (highlightY < table.getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX, highlightY + 1);
+        	table.selectCellAtWithoutClear(highlightX, highlightY + 1);
         } else {
             xAxis.shiftCursorDown();
             yAxis.shiftCursorDown();
@@ -439,9 +372,9 @@ public class Table3DView extends TableView {
 	@Override
 	public void shiftCursorLeft() {
         if (highlightX > 0 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX - 1, highlightY);
+        	table.selectCellAtWithoutClear(highlightX - 1, highlightY);
         } else if (data[highlightX][highlightY].isSelected()) {
-            yAxis.selectCellAt(highlightY);
+            yAxis.getTable().selectCellAt(highlightY);
         } else {
             xAxis.shiftCursorLeft();
             yAxis.shiftCursorLeft();
@@ -451,7 +384,7 @@ public class Table3DView extends TableView {
 	@Override
 	public void shiftCursorRight() {
         if (highlightX < table.getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
-        	selectCellAtWithoutClear(highlightX + 1, highlightY);
+        	table.selectCellAtWithoutClear(highlightX + 1, highlightY);
         } else {
             xAxis.shiftCursorRight();
             yAxis.shiftCursorRight();
@@ -460,8 +393,8 @@ public class Table3DView extends TableView {
 
     @Override
     public void startHighlight(int x, int y) {
-        xAxis.clearSelection();
-        yAxis.clearSelection();
+        xAxis.getTable().clearSelection();
+        yAxis.getTable().clearSelection();
         super.startHighlight(x, y);
     }
 
@@ -577,85 +510,7 @@ public class Table3DView extends TableView {
         }
     }
 
-    @Override
-    public void verticalInterpolate() throws UserLevelException {
-        int[] coords = { table.getSizeX(), table.getSizeY(), 0, 0};
-        DataCellView[][] tableData = get3dData();
-        DataCellView[] axisData = table.getYAxis().getTableView().getData();
-        int i, j;
-        for (i = 0; i < table.getSizeX(); ++i) {
-            for (j = 0; j < table.getSizeY(); ++j) {
-                if (tableData[i][j].isSelected()) {
-                    if (i < coords[0])
-                        coords[0] = i;
-                    if (i > coords[2])
-                        coords[2] = i;
-                    if (j < coords[1])
-                        coords[1] = j;
-                    if (j > coords[3])
-                        coords[3] = j;
-                }
-            }
-        }
-        if (coords[3] - coords[1] > 1) {
-            double x, x1, x2, y1, y2;
-            x1 = axisData[coords[1]].getDataCell().getBinValue();
-            x2 = axisData[coords[3]].getDataCell().getBinValue();
-            for (i = coords[0]; i <= coords[2]; ++i) {
-                y1 = tableData[i][coords[1]].getDataCell().getBinValue();
-                y2 = tableData[i][coords[3]].getDataCell().getBinValue();
-                for (j = coords[1] + 1; j < coords[3]; ++j) {
-                    x = axisData[j].getDataCell().getBinValue();
-                    tableData[i][j].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
-                }
-            }
-        }
-        // Interpolate y axis in case the y axis in selected.
-        table.getYAxis().getTableView().verticalInterpolate();
-    }
-
-    @Override
-    public void horizontalInterpolate() throws UserLevelException {
-        int[] coords = { table.getSizeX(), table.getSizeY(), 0, 0 };
-        DataCellView[][] tableData = get3dData();
-        DataCellView[] axisData = table.getXAxis().getTableView().getData();
-        int i, j;
-        for (i = 0; i < table.getSizeX(); ++i) {
-            for (j = 0; j < table.getSizeY(); ++j) {
-                if (tableData[i][j].isSelected()) {
-                    if (i < coords[0])
-                        coords[0] = i;
-                    if (i > coords[2])
-                        coords[2] = i;
-                    if (j < coords[1])
-                        coords[1] = j;
-                    if (j > coords[3])
-                        coords[3] = j;
-                }
-            }
-        }
-        if (coords[2] - coords[0] > 1) {
-            double x, x1, x2, y1, y2;
-            x1 = axisData[coords[0]].getDataCell().getBinValue();
-            x2 = axisData[coords[2]].getDataCell().getBinValue();
-            for (i = coords[1]; i <= coords[3]; ++i) {
-                y1 = tableData[coords[0]][i].getDataCell().getBinValue();
-                y2 = tableData[coords[2]][i].getDataCell().getBinValue();
-                for (j = coords[0] + 1; j < coords[2]; ++j) {
-                    x = axisData[j].getDataCell().getBinValue();
-                    tableData[j][i].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
-                }
-            }
-        }
-        // Interpolate x axis in case the x axis in selected.
-        table.getXAxis().getTableView().horizontalInterpolate();
-    }
-
-    @Override
-    public void interpolate() throws UserLevelException {
-        verticalInterpolate();
-        horizontalInterpolate();
-    }
+    
 
     @Override
     public void highlightLiveData(String liveValue) {

--- a/src/main/java/com/romraider/maps/Table3DView.java
+++ b/src/main/java/com/romraider/maps/Table3DView.java
@@ -1,0 +1,1164 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2021 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.maps;
+
+import static com.romraider.util.ParamChecker.isNullOrEmpty;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.KeyListener;
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+import java.util.StringTokenizer;
+
+import javax.naming.NameNotFoundException;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
+import javax.swing.border.EmptyBorder;
+
+import com.romraider.Settings;
+import com.romraider.editor.ecu.ECUEditorManager;
+import com.romraider.logger.ecu.ui.swing.vertical.VerticalLabelUI;
+import com.romraider.util.NumberUtil;
+import com.romraider.util.ResourceUtil;
+import com.romraider.util.SettingsManager;
+
+public class Table3D extends Table {
+
+    private static final long serialVersionUID = 3103448753263606599L;
+    private static final ResourceBundle rb = new ResourceUtil().getBundle(
+            Table3D.class.getName());
+    private Table1D xAxis = new Table1D(TableType.X_AXIS);
+    private Table1D yAxis = new Table1D(TableType.Y_AXIS);
+    private JLabel xAxisLabel;
+    private JLabel yAxisLabel;
+
+    DataCellView[][] data = new DataCellView[1][1];
+    private boolean swapXY = false;
+    private boolean flipX = false;
+    private boolean flipY = false;
+
+    CopyTable3DWorker copyTable3DWorker;
+    CopySelection3DWorker copySelection3DWorker;
+
+    public Table3D() {
+        verticalOverhead += 39;
+        horizontalOverhead += 10;
+    }
+
+    @Override
+    public TableType getType() {
+        return Table.TableType.TABLE_3D;
+    }
+
+    public Table1D getXAxis() {
+        return xAxis;
+    }
+
+    public void setXAxis(Table1D xAxis) {
+        this.xAxis = xAxis;
+        xAxis.setAxisParent(this);
+    }
+
+    public Table1D getYAxis() {
+        return yAxis;
+    }
+
+    public void setYAxis(Table1D yAxis) {
+        this.yAxis = yAxis;
+        yAxis.setAxisParent(this);
+    }
+
+    public boolean getSwapXY() {
+        return swapXY;
+    }
+
+    public void setSwapXY(boolean swapXY) {
+        this.swapXY = swapXY;
+    }
+
+    public boolean getFlipX() {
+        return flipX;
+    }
+
+    public void setFlipX(boolean flipX) {
+        this.flipX = flipX;
+    }
+
+    public boolean getFlipY() {
+        return flipY;
+    }
+
+    public void setFlipY(boolean flipY) {
+        this.flipY = flipY;
+    }
+
+    public void setSizeX(int size) {
+        data = new DataCellView[size][data[0].length];
+        centerLayout.setColumns(size + 1);
+    }
+
+    public int getSizeX() {
+        return data.length;
+    }
+
+    public void setSizeY(int size) {
+        data = new DataCellView[data.length][size];
+        centerLayout.setRows(size + 1);
+    }
+
+    public int getSizeY() {
+        return data[0].length;
+    }
+
+    @Override
+    public void drawTable() {
+        for(DataCellView[] column : data) {
+            for(DataCellView cell : column) {
+                if(null != cell) {
+                    cell.drawCell();
+                }
+            }
+        }
+        xAxis.drawTable();
+        yAxis.drawTable();
+    }
+
+    @Override
+    public void populateTable(byte[] input, int romRamOffset) throws NullPointerException, ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+    	this.input = input;
+    	// fill first empty cell
+        centerPanel.add(new JLabel());
+        if (!beforeRam) {
+            this.ramOffset = romRamOffset;
+        }
+
+        // temporarily remove lock
+        boolean tempLock = locked;
+        locked = false;
+
+        // populate axes
+        try {
+            xAxis.populateTable(input, romRamOffset);
+            yAxis.populateTable(input, romRamOffset);
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+
+        for (int x = 0; x < xAxis.getDataSize(); x++) {
+            centerPanel.add(xAxis.getDataCell(x));
+        }
+
+        int offset = 0;
+
+        int iMax = swapXY ? xAxis.getDataSize() : yAxis.getDataSize();
+        int jMax = swapXY ? yAxis.getDataSize() : xAxis.getDataSize();
+        for (int i = 0; i < iMax; i++) {
+            for (int j = 0; j < jMax; j++) {
+
+                int x = flipY ? jMax - j - 1 : j;
+                int y = flipX ? iMax - i - 1 : i;
+                if (swapXY) {
+                    int z = x;
+                    x = y;
+                    y = z;
+                }
+
+                // show locked cell
+                if (tempLock) {
+                    data[x][y].setForeground(Color.GRAY);
+                }
+                
+                DataCell c = new DataCell(this, offset);
+                data[x][y] = new DataCellView(c,x,y);
+                offset++;
+            }
+        }
+
+        for (int y = 0; y < yAxis.getDataSize(); y++) {
+            centerPanel.add(yAxis.getDataCell(y));
+            for (int x = 0; x < xAxis.getDataSize(); x++) {
+                centerPanel.add(data[x][y]);
+            }
+        }
+
+        // reset locked status
+        locked = tempLock;
+
+        GridLayout topLayout = new GridLayout(2, 1);
+        JPanel topPanel = new JPanel(topLayout);
+        this.add(topPanel, BorderLayout.NORTH);
+        topPanel.add(new JLabel(getName(), JLabel.CENTER), BorderLayout.NORTH);
+
+        if(null == xAxis.getName() || xAxis.getName().length() < 1 || Settings.BLANK == xAxis.getName()) {
+            ;// Do not add label.
+        } else if(null == xAxis.getCurrentScale() || "0x" == xAxis.getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            xAxisLabel = new JLabel(xAxis.getName(), JLabel.CENTER);
+            topPanel.add(xAxisLabel, BorderLayout.NORTH);
+        } else {
+            xAxisLabel = new JLabel(xAxis.getName() + " (" + xAxis.getCurrentScale().getUnit() + ")", JLabel.CENTER);
+            topPanel.add(xAxisLabel, BorderLayout.NORTH);
+        }
+
+        yAxisLabel = null;
+        if(null == yAxis.getName() || yAxis.getName().length() < 1 || Settings.BLANK == yAxis.getName()) {
+            ;// Do not add label.
+        } else if(null == yAxis.getCurrentScale() || "0x" == yAxis.getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            yAxisLabel = new JLabel(yAxis.getName());
+        } else {
+            yAxisLabel = new JLabel(yAxis.getName() + " (" + yAxis.getCurrentScale().getUnit() + ")");
+        }
+
+        yAxisLabel.setUI(new VerticalLabelUI(false));
+        add(yAxisLabel, BorderLayout.WEST);
+
+        tableLabel = new JLabel(getCurrentScale().getUnit(), JLabel.CENTER);
+        add(tableLabel, BorderLayout.SOUTH);
+        
+        yAxisLabel.setBorder(new EmptyBorder(2, 4, 2, 4));  
+        
+        if(xAxisLabel!=null)
+        	xAxisLabel.setBorder(new EmptyBorder(2, 4, 2, 4)); 
+        
+        if(presetPanel != null) presetPanel.populatePanel();
+        calcCellRanges();
+    }
+
+    @Override
+    public void updateTableLabel() {
+        if(null == xAxis.getName() || xAxis.getName().length() < 1 || Settings.BLANK == xAxis.getName()) {
+            ;// Do not update label.
+        } else if(null == xAxis.getCurrentScale() || "0x" == xAxis.getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            xAxisLabel.setText(xAxis.getName());
+        } else {
+            xAxisLabel.setText(xAxis.getName() + " (" + xAxis.getCurrentScale().getUnit() + ")");
+        }
+
+        if(null == yAxis.getName() || yAxis.getName().length() < 1 || Settings.BLANK == yAxis.getName()) {
+            ;// Do not update label.
+        } else if(null == yAxis.getCurrentScale() || "0x" == yAxis.getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            yAxisLabel.setText(yAxis.getName());
+        } else {
+            yAxisLabel.setText(yAxis.getName() + " (" + yAxis.getCurrentScale().getUnit() + ")");
+        }
+
+        tableLabel.setText(getCurrentScale().getUnit());
+    }
+
+    @Override
+    public void calcCellRanges() {
+        double binMax = data[0][0].getDataCell().getBinValue();
+        double binMin = data[0][0].getDataCell().getBinValue();
+
+        double compareMax = data[0][0].getDataCell().getCompareValue();
+        double compareMin = data[0][0].getDataCell().getCompareValue();
+
+        for(DataCellView[] column : data) {
+            for(DataCellView cell : column) {
+                // Calc bin
+                if(binMax < cell.getDataCell().getBinValue()) {
+                    binMax = cell.getDataCell().getBinValue();
+                }
+                if(binMin > cell.getDataCell().getBinValue()) {
+                    binMin = cell.getDataCell().getBinValue();
+                }
+
+                // Calc compare
+                double compareValue = cell.getDataCell().getCompareValue();
+                if(compareMax < compareValue) {
+                    compareMax = compareValue;
+                }
+                if(compareMin > compareValue) {
+                    compareMin = compareValue;
+                }
+            }
+        }
+        setMaxBin(binMax);
+        setMinBin(binMin);
+        setMaxCompare(compareMax);
+        setMinCompare(compareMin);
+    }
+
+    @Override
+    public StringBuffer getTableAsString() {
+        StringBuffer output = new StringBuffer(Settings.BLANK);
+
+        output.append(xAxis.getTableAsString());
+        output.append(Settings.NEW_LINE);
+
+        for (int y = 0; y < getSizeY(); y++) {
+            output.append(NumberUtil.stringValue(yAxis.data[y].getDataCell().getRealValue()));
+            output.append(Settings.TAB);
+
+            for (int x = 0; x < getSizeX(); x++) {
+                if (overlayLog) {
+                    output.append(data[x][y].getCellText());
+                }
+                else {
+                    output.append(NumberUtil.stringValue(data[x][y].getDataCell().getRealValue()));
+                }
+                if (x < getSizeX() - 1) {
+                    output.append(Settings.TAB);
+                }
+            }
+
+            if (y < getSizeY() - 1) {
+                output.append(Settings.NEW_LINE);
+            }
+        }
+
+        return output;
+    }
+
+    @Override
+    public void populateCompareValues(Table otherTable) {
+        if(null == otherTable || !(otherTable instanceof Table3D)) {
+            return;
+        }
+
+        Table3D compareTable3D = (Table3D) otherTable;
+        if(data.length != compareTable3D.data.length ||
+                data[0].length != compareTable3D.data[0].length ||
+                xAxis.getDataSize() != compareTable3D.xAxis.getDataSize() ||
+                yAxis.getDataSize() != compareTable3D.yAxis.getDataSize()) {
+            return;
+        }
+
+        clearLiveDataTrace();
+
+        int x=0;
+        for (DataCellView[] column : data) {
+            int y = 0;
+            for(DataCellView cell : column) {
+                cell.getDataCell().setCompareValue(compareTable3D.data[x][y].getDataCell());
+                y++;
+            }
+            x++;
+        }
+
+        xAxis.populateCompareValues(compareTable3D.getXAxis());
+        yAxis.populateCompareValues(compareTable3D.getYAxis());
+
+        calcCellRanges();
+        drawTable();
+    }
+
+    @Override
+    public void refreshCompare() {
+        populateCompareValues(getCompareTable());
+        xAxis.refreshCompare();
+        yAxis.refreshCompare();
+    }
+
+    @Override
+    public Dimension getFrameSize() {
+        int height = verticalOverhead + cellHeight * data[0].length;
+        int width = horizontalOverhead + data.length * cellWidth;
+        if (height < minHeight) {
+            height = minHeight;
+        }
+        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
+        if (width < minWidth) {
+            width = minWidth;
+        }
+        return new Dimension(width, height);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + " (3D)";/* +
+                "\n   Flip X: " + flipX +
+                "\n   Size X: " + data.length +
+                "\n   Flip Y: " + flipY +
+                "\n   Size Y: " + data[0].length +
+                "\n   Swap X/Y: " + swapXY +
+                xAxis +
+                yAxis;*/
+    }
+
+    @Override
+    public void increment(double increment) {
+        if (!locked) {
+            for (int x = 0; x < this.getSizeX(); x++) {
+                for (int y = 0; y < this.getSizeY(); y++) {
+                    if (data[x][y].isSelected()) {
+                        data[x][y].getDataCell().increment(increment);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void multiply(double factor) {
+        if (!locked) {
+            for (int x = 0; x < this.getSizeX(); x++) {
+                for (int y = 0; y < this.getSizeY(); y++) {
+                    if (data[x][y].isSelected()) {
+                    	
+                    	if(getCurrentScale().getName().equals("Raw Value"))
+                    		data[x][y].getDataCell().multiplyRaw(factor);                	
+                    	else 
+                    		data[x][y].getDataCell().multiply(factor);                            
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void clearSelection() {
+        xAxis.clearSelectedData();
+        yAxis.clearSelectedData();
+        clearSelectedData();
+    }
+
+    @Override
+    public void clearSelectedData() {
+        for (int x = 0; x < this.getSizeX(); x++) {
+            for (int y = 0; y < this.getSizeY(); y++) {
+                data[x][y].setSelected(false);
+            }
+        }
+    }
+
+    @Override
+    public void highlight(int xCoord, int yCoord) {
+        if (highlight) {
+            for (int x = 0; x < this.getSizeX(); x++) {
+                for (int y = 0; y < this.getSizeY(); y++) {
+                    if (((y >= highlightY && y <= yCoord) ||
+                            (y <= highlightY && y >= yCoord)) &&
+                            ((x >= highlightX && x <= xCoord) ||
+                                    (x <= highlightX && x >= xCoord))) {
+                        data[x][y].setHighlighted(true);
+                    } else {
+                        data[x][y].setHighlighted(false);
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void stopHighlight() {
+        highlight = false;
+        // loop through, selected and un-highlight
+        for (int x = 0; x < this.getSizeX(); x++) {
+            for (int y = 0; y < this.getSizeY(); y++) {
+                if (data[x][y].isHighlighted()) {
+                    data[x][y].setSelected(true);
+                    data[x][y].setHighlighted(false);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void setRevertPoint() {
+        for (int x = 0; x < this.getSizeX(); x++) {
+            for (int y = 0; y < this.getSizeY(); y++) {
+                data[x][y].getDataCell().setRevertPoint();
+            }
+        }
+        yAxis.setRevertPoint();
+        xAxis.setRevertPoint();
+    }
+
+    @Override
+    public void undoAll() {
+        clearLiveDataTrace();
+        for (int x = 0; x < this.getSizeX(); x++) {
+            for (int y = 0; y < this.getSizeY(); y++) {
+                data[x][y].getDataCell().undo();
+            }
+        }
+        yAxis.undoAll();
+        xAxis.undoAll();
+    }
+
+    @Override
+    public void undoSelected() {
+        clearLiveDataTrace();
+        for (int x = 0; x < this.getSizeX(); x++) {
+            for (int y = 0; y < this.getSizeY(); y++) {
+                if (data[x][y].isSelected()) {
+                    data[x][y].getDataCell().undo();
+                }
+            }
+        }
+    }
+
+
+    @Override
+    public byte[] saveFile(byte[] binData) {
+    	return binData;
+    }
+
+    @Override
+    public void setRealValue(String realValue) {
+        if (!locked && !(userLevel > getSettings().getUserLevel()) ) {
+            for(DataCellView[] column : data) {
+                for(DataCellView cell : column) {
+                    if(cell.isSelected()) {
+                        cell.getDataCell().setRealValue(realValue);
+                    }
+                }
+            }
+        } else if (userLevel > getSettings().getUserLevel()) {
+            JOptionPane.showMessageDialog(this, MessageFormat.format(
+                    rb.getString("USERLVLTOLOW"), userLevel),
+                    rb.getString("TBLNOTMODIFY"),
+                    JOptionPane.INFORMATION_MESSAGE);
+        }
+        xAxis.setRealValue(realValue);
+        yAxis.setRealValue(realValue);
+    }
+
+    @Override
+    public void addKeyListener(KeyListener listener) {
+        xAxis.addKeyListener(listener);
+        yAxis.addKeyListener(listener);
+        for (int x = 0; x < this.getSizeX(); x++) {
+            for (int y = 0; y < this.getSizeY(); y++) {
+                data[x][y].addKeyListener(listener);
+            }
+        }
+    }
+
+    public void selectCellAt(int y, Table1D axisType) {
+        if (axisType.getType() == Table.TableType.Y_AXIS) {
+            selectCellAt(0, y);
+        } else { // y axis
+            selectCellAt(y, 0);
+        }
+        ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(this);
+    }
+
+    public void deSelectCellAt(int x, int y) {
+        clearSelection();
+        data[x][y].setSelected(false);
+        highlightX = x;
+        highlightY = y;
+    }
+
+    public void selectCellAt(int x, int y) {
+        clearSelection();
+        data[x][y].setSelected(true);
+        highlightX = x;
+        highlightY = y;
+    }
+
+    public void selectCellAtWithoutClear(int x, int y) {
+        data[x][y].setSelected(true);
+        highlightX = x;
+        highlightY = y;
+    }
+
+    @Override
+    public void cursorUp() {
+        if (highlightY > 0 && data[highlightX][highlightY].isSelected()) {
+            selectCellAt(highlightX, highlightY - 1);
+        } else if (data[highlightX][highlightY].isSelected()) {
+            xAxis.selectCellAt(highlightX);
+        } else {
+            xAxis.cursorUp();
+            yAxis.cursorUp();
+        }
+    }
+
+    @Override
+    public void cursorDown() {
+        if (highlightY < getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
+            selectCellAt(highlightX, highlightY + 1);
+        } else {
+            xAxis.cursorDown();
+            yAxis.cursorDown();
+        }
+    }
+
+    @Override
+    public void cursorLeft() {
+        if (highlightX > 0 && data[highlightX][highlightY].isSelected()) {
+            selectCellAt(highlightX - 1, highlightY);
+        } else if (data[highlightX][highlightY].isSelected()) {
+            yAxis.selectCellAt(highlightY);
+        } else {
+            xAxis.cursorLeft();
+            yAxis.cursorLeft();
+        }
+    }
+
+    @Override
+    public void cursorRight() {
+        if (highlightX < getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
+            selectCellAt(highlightX + 1, highlightY);
+        } else {
+            xAxis.cursorRight();
+            yAxis.cursorRight();
+        }
+    }
+
+	@Override
+	public void shiftCursorUp() {
+        if (highlightY > 0 && data[highlightX][highlightY].isSelected()) {
+        	selectCellAtWithoutClear(highlightX, highlightY - 1);
+        } else if (data[highlightX][highlightY].isSelected()) {
+        	data[highlightX][highlightY].setSelected(false);
+        	xAxis.selectCellAt(highlightX);
+        } else {
+        	xAxis.cursorUp();
+        	yAxis.shiftCursorUp();
+        }
+	}
+
+	@Override
+	public void shiftCursorDown() {
+        if (highlightY < getSizeY() - 1 && data[highlightX][highlightY].isSelected()) {
+        	selectCellAtWithoutClear(highlightX, highlightY + 1);
+        } else {
+            xAxis.shiftCursorDown();
+            yAxis.shiftCursorDown();
+        }
+	}
+
+	@Override
+	public void shiftCursorLeft() {
+        if (highlightX > 0 && data[highlightX][highlightY].isSelected()) {
+        	selectCellAtWithoutClear(highlightX - 1, highlightY);
+        } else if (data[highlightX][highlightY].isSelected()) {
+            yAxis.selectCellAt(highlightY);
+        } else {
+            xAxis.shiftCursorLeft();
+            yAxis.shiftCursorLeft();
+        }
+	}
+
+	@Override
+	public void shiftCursorRight() {
+        if (highlightX < getSizeX() - 1 && data[highlightX][highlightY].isSelected()) {
+        	selectCellAtWithoutClear(highlightX + 1, highlightY);
+        } else {
+            xAxis.shiftCursorRight();
+            yAxis.shiftCursorRight();
+        }
+	}
+
+    @Override
+    public void startHighlight(int x, int y) {
+        xAxis.clearSelectedData();
+        yAxis.clearSelectedData();
+        super.startHighlight(x, y);
+    }
+
+    @Override
+    public void copySelection() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        copySelection3DWorker = new CopySelection3DWorker(this);
+        copySelection3DWorker.execute();
+
+    }
+
+    @Override
+    public void copyTable() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        copyTable3DWorker = new CopyTable3DWorker(this);
+        copyTable3DWorker.execute();
+    }
+
+    @Override
+    public void paste() {
+        StringTokenizer st = new StringTokenizer(Settings.BLANK);
+        String input = Settings.BLANK;
+        try {
+            input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
+            st = new StringTokenizer(input, ST_DELIMITER);
+        } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
+        } catch (IOException ex) {
+        }
+
+        String pasteType = st.nextToken();
+
+        if ("[Table3D]".equalsIgnoreCase(pasteType)) { // Paste table
+            String currentToken = st.nextToken(Settings.NEW_LINE);
+            if (currentToken.endsWith("\t")) {
+                currentToken = st.nextToken(Settings.NEW_LINE);
+            }
+            String xAxisValues = "[Table1D]" + Settings.NEW_LINE + currentToken;
+
+            // build y axis and data values
+            StringBuffer yAxisValues = new StringBuffer("[Table1D]" + Settings.NEW_LINE + st.nextToken("\t"));
+            StringBuffer dataValues = new StringBuffer("[Table3D]" + Settings.NEW_LINE + st.nextToken("\t") + st.nextToken(Settings.NEW_LINE));
+            while (st.hasMoreTokens()) {
+                yAxisValues.append("\t").append(st.nextToken("\t"));
+                dataValues.append(Settings.NEW_LINE).append(st.nextToken("\t")).append(st.nextToken(Settings.NEW_LINE));
+            }
+
+            // put x axis in clipboard and paste
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(xAxisValues), null);
+            xAxis.paste();
+            // put y axis in clipboard and paste
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(yAxisValues)), null);
+            yAxis.paste();
+            // put datavalues in clipboard and paste
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(dataValues)), null);
+            pasteValues();
+            // reset clipboard
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(input), null);
+
+        } else if ("[Selection3D]".equalsIgnoreCase(pasteType)) { // paste selection
+            pasteValues();
+        } else if ("[Selection1D]".equalsIgnoreCase(pasteType)) { // paste selection
+            xAxis.paste();
+            yAxis.paste();
+        }
+    }
+
+    public void pasteValues() {
+        StringTokenizer st = new StringTokenizer(Settings.BLANK);
+        try {
+            String input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
+            st = new StringTokenizer(input, ST_DELIMITER);
+        } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
+        } catch (IOException ex) {
+        }
+
+        String pasteType = st.nextToken();
+
+        // figure paste start cell
+        int startX = 0;
+        int startY = 0;
+        // if pasting a table, startX and Y at 0, else highlight is start
+        if ("[Selection3D]".equalsIgnoreCase(pasteType)) {
+            startX = highlightX;
+            startY = highlightY;
+        }
+
+        // set values
+        for (int y = startY; st.hasMoreTokens() && y < getSizeY(); y++) {
+            String checkToken = st.nextToken(Settings.NEW_LINE);
+            if (y==startY && checkToken.endsWith("\t")) {
+                checkToken = st.nextToken(Settings.NEW_LINE);
+            }
+            StringTokenizer currentLine = new StringTokenizer(checkToken, ST_DELIMITER);
+            for (int x = startX; currentLine.hasMoreTokens() && x < getSizeX(); x++) {
+                String currentToken = currentLine.nextToken();
+
+                try {
+                    if (!data[x][y].getText().equalsIgnoreCase(currentToken)) {
+                        data[x][y].getDataCell().setRealValue(currentToken);
+                    }
+                } catch (ArrayIndexOutOfBoundsException ex) { /* copied table is larger than current table*/ }
+            }
+        }
+    }
+
+    @Override
+    public void verticalInterpolate() {
+        int[] coords = { getSizeX(), getSizeY(), 0, 0};
+        DataCellView[][] tableData = get3dData();
+        DataCellView[] axisData = getYAxis().getData();
+        int i, j;
+        for (i = 0; i < getSizeX(); ++i) {
+            for (j = 0; j < getSizeY(); ++j) {
+                if (tableData[i][j].isSelected()) {
+                    if (i < coords[0])
+                        coords[0] = i;
+                    if (i > coords[2])
+                        coords[2] = i;
+                    if (j < coords[1])
+                        coords[1] = j;
+                    if (j > coords[3])
+                        coords[3] = j;
+                }
+            }
+        }
+        if (coords[3] - coords[1] > 1) {
+            double x, x1, x2, y1, y2;
+            x1 = axisData[coords[1]].getDataCell().getBinValue();
+            x2 = axisData[coords[3]].getDataCell().getBinValue();
+            for (i = coords[0]; i <= coords[2]; ++i) {
+                y1 = tableData[i][coords[1]].getDataCell().getBinValue();
+                y2 = tableData[i][coords[3]].getDataCell().getBinValue();
+                for (j = coords[1] + 1; j < coords[3]; ++j) {
+                    x = axisData[j].getDataCell().getBinValue();
+                    tableData[i][j].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
+                }
+            }
+        }
+        // Interpolate y axis in case the y axis in selected.
+        this.getYAxis().verticalInterpolate();
+    }
+
+    @Override
+    public void horizontalInterpolate() {
+        int[] coords = { getSizeX(), getSizeY(), 0, 0 };
+        DataCellView[][] tableData = get3dData();
+        DataCellView[] axisData = getXAxis().getData();
+        int i, j;
+        for (i = 0; i < getSizeX(); ++i) {
+            for (j = 0; j < getSizeY(); ++j) {
+                if (tableData[i][j].isSelected()) {
+                    if (i < coords[0])
+                        coords[0] = i;
+                    if (i > coords[2])
+                        coords[2] = i;
+                    if (j < coords[1])
+                        coords[1] = j;
+                    if (j > coords[3])
+                        coords[3] = j;
+                }
+            }
+        }
+        if (coords[2] - coords[0] > 1) {
+            double x, x1, x2, y1, y2;
+            x1 = axisData[coords[0]].getDataCell().getBinValue();
+            x2 = axisData[coords[2]].getDataCell().getBinValue();
+            for (i = coords[1]; i <= coords[3]; ++i) {
+                y1 = tableData[coords[0]][i].getDataCell().getBinValue();
+                y2 = tableData[coords[2]][i].getDataCell().getBinValue();
+                for (j = coords[0] + 1; j < coords[2]; ++j) {
+                    x = axisData[j].getDataCell().getBinValue();
+                    tableData[j][i].getDataCell().setBinValue(linearInterpolation(x, x1, x2, y1, y2));
+                }
+            }
+        }
+        // Interpolate x axis in case the x axis in selected.
+        this.getXAxis().horizontalInterpolate();
+    }
+
+    @Override
+    public void interpolate() {
+        verticalInterpolate();
+        horizontalInterpolate();
+    }
+
+    @Override
+    public boolean isLiveDataSupported() {
+        return !isNullOrEmpty(xAxis.getLogParam()) && !isNullOrEmpty(yAxis.getLogParam());
+    }
+
+    @Override
+    public boolean isButtonSelected() {
+        return true;
+    }
+
+    @Override
+    public void highlightLiveData(String liveValue) {
+        if (getOverlayLog()) {
+            int x = xAxis.getLiveDataIndex();
+            int y = yAxis.getLiveDataIndex();
+            DataCellView cell = data[x][y];
+            cell.setLiveDataTrace(true);
+            cell.getDataCell().setLiveDataTraceValue(liveValue);
+            getToolbar().setLiveDataValue(liveValue);
+        }
+    }
+
+    @Override
+    public void updateLiveDataHighlight() {
+        if (getOverlayLog()) {
+            int x = xAxis.getLiveDataIndex();
+            int y = yAxis.getLiveDataIndex();
+            int xp = xAxis.getPreviousLiveDataIndex();
+            int yp = yAxis.getPreviousLiveDataIndex();
+            data[xp][yp].setPreviousLiveDataTrace(true);
+            data[x][y].setPreviousLiveDataTrace(false);
+            data[x][y].setLiveDataTrace(true);
+        }
+    }
+
+    @Override
+    public void clearLiveDataTrace() {
+        xAxis.clearLiveDataTrace();
+        yAxis.clearLiveDataTrace();
+        for (int x = 0; x < getSizeX(); x++) {
+            for (int y = 0; y < getSizeY(); y++) {
+                data[x][y].setLiveDataTrace(false);
+                data[x][y].setPreviousLiveDataTrace(false);
+            }
+        }
+    }
+
+    public DataCellView[][] get3dData() {
+        return data;
+    }
+
+    @Override
+    public void setCompareDisplay(Settings.CompareDisplay compareDisplay) {
+        super.setCompareDisplay(compareDisplay);
+        xAxis.setCompareDisplay(compareDisplay);
+        yAxis.setCompareDisplay(compareDisplay);
+    }
+
+    @Override
+    public void setCompareValueType(Settings.DataType compareValueType) {
+        super.setCompareValueType(compareValueType);
+        xAxis.setCompareValueType(compareValueType);
+        yAxis.setCompareValueType(compareValueType);
+    }
+
+    @Override
+    public void setCurrentScale(Scale curScale) {
+        if(SettingsManager.getSettings().isScaleHeadersAndData()) {
+            if(!xAxis.isStaticDataTable()) {
+                try {
+                    this.xAxis.setScaleByName(curScale.getName());
+                } catch (NameNotFoundException e) {
+                    try {
+                        this.xAxis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
+                    } catch (NameNotFoundException e1) {
+                    }
+                }
+            }
+            if(!yAxis.isStaticDataTable()) {
+                try {
+                    this.yAxis.setScaleByName(curScale.getName());
+                } catch (NameNotFoundException e) {
+                    try {
+                        this.yAxis.setScaleByName(SettingsManager.getSettings().getDefaultScale());
+                    } catch (NameNotFoundException e1) {
+                    }
+                }
+            }
+        }
+        this.curScale = curScale;
+        updateTableLabel();
+        drawTable();
+    }
+
+    @Override
+    public String getLogParamString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(xAxis.getLogParamString()+", ");
+        sb.append(yAxis.getLogParamString()+", ");
+        sb.append(getName()+ ":" + getLogParam());
+        return sb.toString();
+    }
+
+    @Override
+    public void setOverlayLog(boolean overlayLog) {
+        super.setOverlayLog(overlayLog);
+        xAxis.setOverlayLog(overlayLog);
+        yAxis.setOverlayLog(overlayLog);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        try {
+            if(null == other) {
+                return false;
+            }
+
+            if(other == this) {
+                return true;
+            }
+
+            if(!(other instanceof Table3D)) {
+                return false;
+            }
+
+            Table3D otherTable = (Table3D)other;
+
+            if( (null == this.getName() && null == otherTable.getName())
+                    || (this.getName().isEmpty() && otherTable.getName().isEmpty()) ) {
+                ;// Skip name compare if name is null or empty.
+            } else if(!this.getName().equalsIgnoreCase(otherTable.getName())) {
+                return false;
+            }
+
+            if(! this.xAxis.equals(otherTable.xAxis)) {
+                return false;
+            }
+
+            if(! this.yAxis.equals(otherTable.yAxis)) {
+                return false;
+            }
+
+            if(this.data.length != otherTable.data.length || this.data[0].length != otherTable.data[0].length)
+            {
+                return false;
+            }
+
+            if(this.data.equals(otherTable.data))
+            {
+                return true;
+            }
+
+            // Compare Bin Values
+            for(int i = 0 ; i < this.data.length ; i++) {
+                for(int j = 0; j < this.data[i].length ; j++) {
+                    if(! this.data[i][j].equals(otherTable.data[i][j]) ) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        } catch(Exception ex) {
+            // TODO: Log Exception.
+            return false;
+        }
+    }
+
+    @Override
+    public void repaint() {
+        super.repaint();
+
+        if(null != xAxis) {
+            xAxis.repaint();
+        }
+
+        if(null != yAxis) {
+            yAxis.repaint();
+        }
+    }
+}
+
+class CopySelection3DWorker extends SwingWorker<Void, Void> {
+    Table3D table;
+
+    public CopySelection3DWorker(Table3D table)
+    {
+        this.table = table;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        // find bounds of selection
+        // coords[0] = x min, y min, x max, y max
+        boolean copy = false;
+        int[] coords = new int[4];
+        coords[0] = table.getSizeX();
+        coords[1] = table.getSizeY();
+
+        for (int x = 0; x < table.getSizeX(); x++) {
+            for (int y = 0; y < table.getSizeY(); y++) {
+                if (table.get3dData()[x][y].isSelected()) {
+                    if (x < coords[0]) {
+                        coords[0] = x;
+                        copy = true;
+                    }
+                    if (x > coords[2]) {
+                        coords[2] = x;
+                        copy = true;
+                    }
+                    if (y < coords[1]) {
+                        coords[1] = y;
+                        copy = true;
+                    }
+                    if (y > coords[3]) {
+                        coords[3] = y;
+                        copy = true;
+                    }
+                }
+            }
+        }
+        // make string of selection
+        if (copy) {
+            StringBuffer output = new StringBuffer("[Selection3D]" + Settings.NEW_LINE);
+            for (int y = coords[1]; y <= coords[3]; y++) {
+                for (int x = coords[0]; x <= coords[2]; x++) {
+                    if (table.get3dData()[x][y].isSelected()) {
+                        output.append(NumberUtil.stringValue(table.get3dData()[x][y].getDataCell().getRealValue()));
+                    } else {
+                        output.append("x"); // x represents non-selected cell
+                    }
+                    if (x < coords[2]) {
+                        output.append("\t");
+                    }
+                }
+                if (y < coords[3]) {
+                    output.append(Settings.NEW_LINE);
+                }
+                //copy to clipboard
+                Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
+            }
+        } else {
+            table.getXAxis().copySelection();
+            table.getYAxis().copySelection();
+        }
+        return null;
+    }
+
+    @Override
+    public void done() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(null);
+        }
+        table.setCursor(null);
+        ECUEditorManager.getECUEditor().setCursor(null);
+    }
+}
+
+class CopyTable3DWorker extends SwingWorker<Void, Void> {
+    Table3D table;
+
+    public CopyTable3DWorker(Table3D table)
+    {
+        this.table = table;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        String tableHeader = table.getSettings().getTable3DHeader();
+        StringBuffer output = new StringBuffer(tableHeader);
+        output.append(table.getTableAsString());
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
+        return null;
+    }
+
+    @Override
+    public void done() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow){
+            ancestorWindow.setCursor(null);
+        }
+        table.setCursor(null);
+        ECUEditorManager.getECUEditor().setCursor(null);
+    }
+}

--- a/src/main/java/com/romraider/maps/Table3DView.java
+++ b/src/main/java/com/romraider/maps/Table3DView.java
@@ -32,7 +32,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.KeyListener;
 import java.io.IOException;
 
-import java.util.ResourceBundle;
 import java.util.StringTokenizer;
 
 import javax.swing.JLabel;
@@ -45,12 +44,11 @@ import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.logger.ecu.ui.swing.vertical.VerticalLabelUI;
 import com.romraider.util.NumberUtil;
-import com.romraider.util.ResourceUtil;
 
 public class Table3DView extends TableView {
 
     private static final long serialVersionUID = 3103448753263606599L;
-    private static final ResourceBundle rb = new ResourceUtil().getBundle(Table3DView.class.getName());
+   // private static final ResourceBundle rb = new ResourceUtil().getBundle(Table3DView.class.getName());
     private Table3D table;
     private Table1DView xAxis;
     private Table1DView yAxis;

--- a/src/main/java/com/romraider/maps/Table3DView.java
+++ b/src/main/java/com/romraider/maps/Table3DView.java
@@ -19,13 +19,9 @@
 
 package com.romraider.maps;
 
-import static com.romraider.util.ParamChecker.isNullOrEmpty;
-
-import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
-import java.awt.GridLayout;
+
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.datatransfer.DataFlavor;
@@ -33,24 +29,20 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.KeyListener;
 import java.io.IOException;
-import java.text.MessageFormat;
+
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
 
-import javax.naming.NameNotFoundException;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
-import javax.swing.border.EmptyBorder;
+
 
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
-import com.romraider.logger.ecu.ui.swing.vertical.VerticalLabelUI;
+import com.romraider.swing.TableFrame;
 import com.romraider.util.NumberUtil;
 import com.romraider.util.ResourceUtil;
-import com.romraider.util.SettingsManager;
 
 public class Table3DView extends TableView {
 
@@ -67,10 +59,10 @@ public class Table3DView extends TableView {
     CopyTable3DWorker copyTable3DWorker;
     CopySelection3DWorker copySelection3DWorker;
 
-    public Table3DView(Table3D table) {
-    	super(table);
-    	xAxis = new Table1DView(table.getXAxis());
-    	yAxis = new Table1DView(table.getYAxis());
+    public Table3DView(Table3D table, TableFrame frame) {
+    	super(table, frame);
+    	xAxis = new Table1DView(table.getXAxis(), frame);
+    	yAxis = new Table1DView(table.getYAxis(), frame);
     	
         verticalOverhead += 39;
         horizontalOverhead += 10;
@@ -212,38 +204,6 @@ public class Table3DView extends TableView {
         }
 
         tableLabel.setText(table.getCurrentScale().getUnit());
-    }
-
-  
-    @Override
-    public StringBuffer getTableAsString() {
-        StringBuffer output = new StringBuffer(Settings.BLANK);
-
-        output.append(xAxis.getTableAsString());
-        output.append(Settings.NEW_LINE);
-
-        for (int y = 0; y < table.getSizeY(); y++) {
-            output.append(NumberUtil.stringValue(yAxis.data[y].getDataCell().getRealValue()));
-            output.append(Settings.TAB);
-
-            for (int x = 0; x < table.getSizeX(); x++) {
-                if (overlayLog) {
-                    output.append(data[x][y].getCellText());
-                }
-                else {
-                    output.append(NumberUtil.stringValue(data[x][y].getDataCell().getRealValue()));
-                }
-                if (x < table.getSizeX() - 1) {
-                    output.append(Settings.TAB);
-                }
-            }
-
-            if (y < table.getSizeY() - 1) {
-                output.append(Settings.NEW_LINE);
-            }
-        }
-
-        return output;
     }
 
     @Override
@@ -855,7 +815,7 @@ class CopyTable3DWorker extends SwingWorker<Void, Void> {
     protected Void doInBackground() throws Exception {
         String tableHeader = TableView.getSettings().getTable3DHeader();
         StringBuffer output = new StringBuffer(tableHeader);
-        output.append(tableView.getTableAsString());
+        output.append(tableView.getTable().getTableAsString());
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
         return null;
     }

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -19,11 +19,7 @@
 
 package com.romraider.maps;
 
-import java.awt.BorderLayout;
 import java.awt.GridLayout;
-import java.awt.Insets;
-import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -31,66 +27,30 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Map.Entry;
 
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JTextArea;
 
 import com.romraider.util.ByteUtil;
-import com.romraider.util.ResourceUtil;
-
-import static javax.swing.JOptionPane.ERROR_MESSAGE;
-import static javax.swing.JOptionPane.showMessageDialog;
 
 public class TableBitwiseSwitch extends Table {
-
-	@Override
-	public TableType getType() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public byte[] saveFile(byte[] binData) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public boolean isLiveDataSupported() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean isButtonSelected() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-/*
 	private static final long serialVersionUID = -4887718305447362308L;
-    private static final ResourceBundle rb = new ResourceUtil().getBundle(
-            TableBitwiseSwitch.class.getName());
-	private final Map<String, Integer> controlBits = new HashMap<String, Integer>();
-	private ArrayList<JCheckBox> checkboxes;
-	private int dataSize = 1;
 
+	private final Map<String, Integer> controlBits = new HashMap<String, Integer>();
+	private int dataSize = 1;
+	private boolean[] bits_array;
 	public TableBitwiseSwitch() {
 		super();
 		storageType = 1;
-		removeAll();
-		setLayout(new BorderLayout());
-		checkboxes = new ArrayList<JCheckBox>();
 	}
 
 	@Override
 	public void populateTable(byte[] input, int romRamOffset)
 			throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
 		int maxBitPosition = ((dataSize * 8) - 1);
-		boolean[] bits_array = new boolean[maxBitPosition + 1];
+		bits_array = new boolean[maxBitPosition + 1];
 
 		for (int i = 0; i < dataSize; i++) {
 			boolean[] byte_values = ByteUtil.byteToBoolArr(input[storageAddress + i]);
@@ -101,24 +61,16 @@ public class TableBitwiseSwitch extends Table {
 
 		JPanel radioPanel = new JPanel(new GridLayout(0, 1));
 		radioPanel.add(new JLabel("  " + getName()));
-
-		for (Entry<String, Integer> entry : sortByValue(controlBits).entrySet()) {
-			if (entry.getValue() > maxBitPosition) {
-				String mismatch = MessageFormat.format(
-						rb.getString("OUTOFRANGE"), super.getName());
-				showMessageDialog(this, mismatch,
-				        rb.getString("DEFERROR"), ERROR_MESSAGE);
-				break;
-			} else {
-				JCheckBox cb = new JCheckBox(entry.getKey());
-				cb.setSelected(bits_array[entry.getValue()]);
-				checkboxes.add(cb);
-				radioPanel.add(cb);
-			}
-		}
-		add(radioPanel, BorderLayout.CENTER);
 	}
-
+	
+	public Map<String, Integer> getControlBits() {
+		return controlBits;
+	}
+	
+	public boolean[] getBitsArray() {
+		return bits_array;
+	}
+	
 	@Override
 	public void setName(String name) {
 		super.setName(name);
@@ -130,20 +82,6 @@ public class TableBitwiseSwitch extends Table {
 	}
 
 	@Override
-	public void setDescription(String description) {
-		super.setDescription(description);
-		JTextArea descriptionArea = new JTextArea(description);
-		descriptionArea.setOpaque(false);
-		descriptionArea.setEditable(false);
-		descriptionArea.setWrapStyleWord(true);
-		descriptionArea.setLineWrap(true);
-		descriptionArea.setMargin(new Insets(0, 5, 5, 5));
-
-		add(descriptionArea, BorderLayout.SOUTH);
-	}
-
-
-	@Override
 	public byte[] saveFile(byte[] input) {
 
 		for (Entry<String, Integer> entry : controlBits.entrySet()) {
@@ -152,13 +90,33 @@ public class TableBitwiseSwitch extends Table {
 
 			boolean[] bools = ByteUtil.byteToBoolArr(input[storageAddress + entry_offset]);
 			JCheckBox cb = getButtonByText(entry.getKey());
-			bools[bitpos] = cb.isSelected();
-			byte result = ByteUtil.booleanArrayToBit(bools);
-
-			input[storageAddress + entry_offset] = result;
+			
+			if(cb != null) {
+				bools[bitpos] = cb.isSelected();
+				byte result = ByteUtil.booleanArrayToBit(bools);
+	
+				input[storageAddress + entry_offset] = result;
+			}
 		}
 
 		return input;
+	}
+	
+	//This is bad design
+	private JCheckBox getButtonByText(String text) {
+		TableView v = getTableView();
+		
+		if(v != null) {
+			TableBitwiseSwitchView bv = (TableBitwiseSwitchView)v;
+			
+			for (JCheckBox cb : bv.getCheckboxes()) {
+				if (cb.getText().equalsIgnoreCase(text)) {
+					return cb;
+				}
+			}
+		}
+		
+		return null;
 	}
 	
     @Override
@@ -172,38 +130,6 @@ public class TableBitwiseSwitch extends Table {
 
 	public Map<String, Integer> getSwitchStates() {
 		return this.controlBits;
-	}
-
-	@Override
-	public void cursorUp() {
-	}
-
-	@Override
-	public void cursorDown() {
-	}
-
-	@Override
-	public void cursorLeft() {
-	}
-
-	@Override
-	public void cursorRight() {
-	}
-
-	@Override
-	public void shiftCursorUp() {
-	}
-
-	@Override
-	public void shiftCursorDown() {
-	}
-
-	@Override
-	public void shiftCursorLeft() {
-	}
-
-	@Override
-	public void shiftCursorRight() {
 	}
 
 	@Override
@@ -270,16 +196,6 @@ public class TableBitwiseSwitch extends Table {
 	}
 
 	@Override
-	public void drawTable() {
-		return; // Do nothing.
-	}
-
-	@Override
-	public void updateTableLabel() {
-		return; // Do nothing.
-	}
-
-	@Override
 	public void setCurrentScale(Scale curScale) {
 		return; // Do nothing.
 	}
@@ -290,16 +206,7 @@ public class TableBitwiseSwitch extends Table {
 		return false;
 	}
 
-	private JCheckBox getButtonByText(String text) {
-		for (JCheckBox cb : checkboxes) {
-			if (cb.getText().equalsIgnoreCase(text)) {
-				return cb;
-			}
-		}
-		return null;
-	}
-
-	private Map<String, Integer> sortByValue(Map<String, Integer> unsortMap) {
+	static Map<String, Integer> sortByValue(Map<String, Integer> unsortMap) {
 		List<Map.Entry<String, Integer>> list =
 						new LinkedList<Map.Entry<String, Integer>>(unsortMap.entrySet());
 		Collections.sort(list, new Comparator<Map.Entry<String, Integer>>() {
@@ -315,5 +222,5 @@ public class TableBitwiseSwitch extends Table {
 		}
 
 		return sortedMap;
-	}*/
+	}
 }

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -47,6 +47,30 @@ import static javax.swing.JOptionPane.showMessageDialog;
 
 public class TableBitwiseSwitch extends Table {
 
+	@Override
+	public TableType getType() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public byte[] saveFile(byte[] binData) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isLiveDataSupported() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isButtonSelected() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+/*
 	private static final long serialVersionUID = -4887718305447362308L;
     private static final ResourceBundle rb = new ResourceUtil().getBundle(
             TableBitwiseSwitch.class.getName());
@@ -291,5 +315,5 @@ public class TableBitwiseSwitch extends Table {
 		}
 
 		return sortedMap;
-	}
+	}*/
 }

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -47,11 +47,11 @@ public class TableBitwiseSwitch extends Table {
 	}
 
 	@Override
-	public void populateTable(byte[] input, int romRamOffset)
-			throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+	public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
 		int maxBitPosition = ((dataSize * 8) - 1);
 		bits_array = new boolean[maxBitPosition + 1];
-
+		byte[] input = rom.getBinary();
+		
 		for (int i = 0; i < dataSize; i++) {
 			boolean[] byte_values = ByteUtil.byteToBoolArr(input[storageAddress + i]);
 			for (int j = 0; j < 8; j++) {

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitchView.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitchView.java
@@ -48,9 +48,11 @@ public class TableBitwiseSwitchView extends TableView {
 
 	public TableBitwiseSwitchView(TableBitwiseSwitch table) {
 		super(table);
+		this.table = table;
 		removeAll();
 		setLayout(new BorderLayout());
 		checkboxes = new ArrayList<JCheckBox>();
+		populateTableVisual();
 	}
 
 	@Override

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitchView.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitchView.java
@@ -1,0 +1,139 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2020 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.maps;
+
+import java.awt.BorderLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.ResourceBundle;
+import java.util.Map.Entry;
+
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+
+import com.romraider.util.ResourceUtil;
+
+import static javax.swing.JOptionPane.ERROR_MESSAGE;
+import static javax.swing.JOptionPane.showMessageDialog;
+
+public class TableBitwiseSwitchView extends TableView {
+
+	private static final long serialVersionUID = -4887718305447362308L;
+    private static final ResourceBundle rb = new ResourceUtil().getBundle(
+            TableBitwiseSwitch.class.getName());
+	private ArrayList<JCheckBox> checkboxes;
+	private TableBitwiseSwitch table;
+
+
+	public TableBitwiseSwitchView(TableBitwiseSwitch table) {
+		super(table);
+		removeAll();
+		setLayout(new BorderLayout());
+		checkboxes = new ArrayList<JCheckBox>();
+	}
+
+	@Override
+	public void populateTableVisual()
+			throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+		int maxBitPosition = ((table.getDataSize() * 8) - 1);
+		JPanel radioPanel = new JPanel(new GridLayout(0, 1));
+		radioPanel.add(new JLabel("  " + getName()));
+
+		for (Entry<String, Integer> entry : TableBitwiseSwitch.sortByValue(table.getControlBits()).entrySet()) {
+			if (entry.getValue() > maxBitPosition) {
+				String mismatch = MessageFormat.format(
+						rb.getString("OUTOFRANGE"), super.getName());
+				showMessageDialog(this, mismatch,
+				        rb.getString("DEFERROR"), ERROR_MESSAGE);
+				break;
+			} else {
+				JCheckBox cb = new JCheckBox(entry.getKey());
+				cb.setSelected(table.getBitsArray()[entry.getValue()]);
+				checkboxes.add(cb);
+				radioPanel.add(cb);
+			}
+		}
+		add(radioPanel, BorderLayout.CENTER);
+		
+		JTextArea descriptionArea = new JTextArea(table.getDescription());
+		descriptionArea.setOpaque(false);
+		descriptionArea.setEditable(false);
+		descriptionArea.setWrapStyleWord(true);
+		descriptionArea.setLineWrap(true);
+		descriptionArea.setMargin(new Insets(0, 5, 5, 5));
+
+		add(descriptionArea, BorderLayout.SOUTH);
+	}
+
+	public ArrayList<JCheckBox> getCheckboxes() {
+		return checkboxes;
+	}
+	
+	@Override
+	public void setName(String name) {
+		super.setName(name);
+	}
+
+	@Override
+	public void cursorUp() {
+	}
+
+	@Override
+	public void cursorDown() {
+	}
+
+	@Override
+	public void cursorLeft() {
+	}
+
+	@Override
+	public void cursorRight() {
+	}
+
+	@Override
+	public void shiftCursorUp() {
+	}
+
+	@Override
+	public void shiftCursorDown() {
+	}
+
+	@Override
+	public void shiftCursorLeft() {
+	}
+
+	@Override
+	public void shiftCursorRight() {
+	}
+
+	@Override
+	public void drawTable() {
+		return; // Do nothing.
+	}
+
+	@Override
+	public void updateTableLabel() {
+		return; // Do nothing.
+	}
+}

--- a/src/main/java/com/romraider/maps/TableSwitch.java
+++ b/src/main/java/com/romraider/maps/TableSwitch.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
+import java.util.Vector;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
@@ -49,6 +50,31 @@ import javax.swing.JTextArea;
 import com.romraider.util.ResourceUtil;
 
 public class TableSwitch extends Table {
+
+	@Override
+	public TableType getType() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public byte[] saveFile(byte[] binData) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public boolean isLiveDataSupported() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public boolean isButtonSelected() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+	/*
     private static final long serialVersionUID = -4887718305447362308L;
     private static final ResourceBundle rb = new ResourceUtil().getBundle(
             TableSwitch.class.getName());
@@ -401,5 +427,10 @@ public class TableSwitch extends Table {
             }
         }
         return null;
-    }
+    }*/
+
+	public Vector<Scale> getSwitchStates() {
+		// TODO Auto-generated method stub
+		return null;
+	}
 }

--- a/src/main/java/com/romraider/maps/TableSwitch.java
+++ b/src/main/java/com/romraider/maps/TableSwitch.java
@@ -20,417 +20,65 @@
 package com.romraider.maps;
 
 import static com.romraider.maps.RomChecksum.validateRomChecksum;
-import static com.romraider.util.ByteUtil.indexOfBytes;
-import static com.romraider.util.HexUtil.asBytes;
-import static javax.swing.JOptionPane.ERROR_MESSAGE;
 import static javax.swing.JOptionPane.INFORMATION_MESSAGE;
 import static javax.swing.JOptionPane.WARNING_MESSAGE;
 import static javax.swing.JOptionPane.showMessageDialog;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridLayout;
-import java.awt.Insets;
 import java.text.MessageFormat;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.Set;
-import java.util.Vector;
-
-import javax.swing.AbstractButton;
-import javax.swing.ButtonGroup;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JTextArea;
 
 import com.romraider.util.ResourceUtil;
 
-public class TableSwitch extends Table {
-
-	@Override
-	public TableType getType() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public byte[] saveFile(byte[] binData) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public boolean isLiveDataSupported() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	@Override
-	public boolean isButtonSelected() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-	/*
+public class TableSwitch extends Table1D {
     private static final long serialVersionUID = -4887718305447362308L;
     private static final ResourceBundle rb = new ResourceUtil().getBundle(
             TableSwitch.class.getName());
-    private final ButtonGroup buttonGroup = new ButtonGroup();
-    private final Map<String, byte[]> switchStates = new HashMap<String, byte[]>();
-    private int dataSize = 0;
-
+    
     public TableSwitch() {
-        super();
+    	super(TableType.SWITCH);
         storageType = 1;
-        locked = true;
-        removeAll();
-        setLayout(new BorderLayout());
     }
-
-    @Override
-    public void setDataSize(int size) {
-        if (dataSize == 0) dataSize = size;
-    }
-
-    @Override
-    public int getDataSize() {
-        return dataSize;
-    }
-
-    @Override
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException  {
-        JPanel radioPanel = new JPanel(new GridLayout(0, 1));
-        radioPanel.add(new JLabel("  " + getName()));
-        for (String stateName : switchStates.keySet()) {
-            JRadioButton button = new JRadioButton(stateName);
-            buttonGroup.add(button);
-            radioPanel.add(button);
-        }
-        add(radioPanel, BorderLayout.CENTER);
-
-        // Validate the ROM image checksums.
-        // if the result is >0: position of failed checksum
-        // if the result is  0: all the checksums matched
-        // if the result is -1: all the checksums have been previously disabled
-        if (super.getName().contains("Checksum Fix")) {
-            int result = validateRomChecksum(input, getStorageAddress(), dataSize);
-            String message = MessageFormat.format(
-                    rb.getString("CHKSUMINVALID"), result, super.getName());
-            if (result > 0) {
-                showMessageDialog(this,
-                        message,
-                        rb.getString("CHKSUMSFAILED"),
-                        WARNING_MESSAGE);
-                setButtonsUnselected(buttonGroup);
-            }
-            else if (result == -1){
-                message = rb.getString("ALLDISABLED");
-                showMessageDialog(this,
-                        message,
-                        rb.getString("CHKSUMSTATUS"),
-                        INFORMATION_MESSAGE);
-                getButtonByText(buttonGroup, "on").setSelected(true);
-            }
-            else {
-                getButtonByText(buttonGroup, "off").setSelected(true);
-                locked = false;
-            }
-            return;
-        }
-
-        // Validate XML switch definition data against the ROM data to select
-        // the appropriate switch setting or throw an error if there is a
-        // mismatch and disable this table's editing ability.
-        if (!beforeRam) {
-            this.ramOffset = romRamOffset;
-        }
-        Map<String, Integer> sourceStatus = new HashMap<String, Integer>();
-        for (String stateName : switchStates.keySet()) {
-            byte[] sourceData = new byte[dataSize];
-            System.arraycopy(
-                    input,
-                    storageAddress - ramOffset,
-                    sourceData,
-                    0,
-                    dataSize);
-            int compareResult = indexOfBytes(sourceData, getValues(stateName));
-            if (compareResult == -1) {
-                getButtonByText(buttonGroup, stateName).setSelected(false);
-            }
-            else {
-                getButtonByText(buttonGroup, stateName).setSelected(true);
-            }
-            sourceStatus.put(stateName, compareResult);
-        }
-
-        for (String source : sourceStatus.keySet()) {
-            if (sourceStatus.get(source) != -1) {
-                locked = false;
-                break;
-            }
-        }
-
-        if (locked) {
-            String mismatch = MessageFormat.format(
-                    rb.getString("EDITDISABLE"), super.getName());
-            showMessageDialog(this,
-                    mismatch,
-                    rb.getString("DATAMISMATCH"),
-                    ERROR_MESSAGE);
-            setButtonsUnselected(buttonGroup);
-        }
-    }
-
-    @Override
-    public void setName(String name) {
-        super.setName(name);
-    }
-
+   
     @Override
     public TableType getType() {
         return Table.TableType.SWITCH;
     }
-
-    @Override
-    public void setDescription(String description) {
-        super.setDescription(description);
-        JTextArea descriptionArea = new JTextArea(description);
-        descriptionArea.setOpaque(false);
-        descriptionArea.setEditable(false);
-        descriptionArea.setWrapStyleWord(true);
-        descriptionArea.setLineWrap(true);
-        descriptionArea.setMargin(new Insets(0,5,5,5));
-
-        add(descriptionArea, BorderLayout.SOUTH);
-    }
-
     
+    //TODO: Clean this up!
     @Override
-    public byte[] saveFile(byte[] input) {
-        if (!super.getName().contains("Checksum Fix")) {
-            if (!locked) {
-                JRadioButton selectedButton = getSelectedButton(buttonGroup);
-                System.arraycopy(
-                        switchStates.get(selectedButton.getText()),
-                        0,
-                        input,
-                        getStorageAddress() - ramOffset,
-                        dataSize);
-            }
-        }
-        return input;
+    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+        super.populateTable(input,romRamOffset);
+        
+	    // Validate the ROM image checksums.
+	    // if the result is >0: position of failed checksum
+	    // if the result is  0: all the checksums matched
+	    // if the result is -1: all the checksums have been previously disabled
+	    if (super.getName().contains("Checksum Fix")) {
+	        int result = validateRomChecksum(getDataCell(0).getBinary(),
+	        		getStorageAddress(), getDataSize());
+	        
+	        String message = MessageFormat.format(
+	                rb.getString("CHKSUMINVALID"), result, super.getName());
+	        if (result > 0) {
+	            showMessageDialog(null,
+	                    message,
+	                    rb.getString("CHKSUMSFAILED"),
+	                    WARNING_MESSAGE);
+	           // setButtonsUnselected(buttonGroup);
+	        }
+	        else if (result == -1){
+	            message = rb.getString("ALLDISABLED");
+	            showMessageDialog(null,
+	                    message,
+	                    rb.getString("CHKSUMSTATUS"),
+	                    INFORMATION_MESSAGE);
+	            //getButtonByText(buttonGroup, "on").setSelected(true);
+	        }
+	        else {
+	            //getButtonByText(buttonGroup, "off").setSelected(true);
+	            locked = false;
+	        }
+	        return;
+	    }
     }
-
-    @Override
-    public void setValues(String name, String input) {
-        switchStates.put(name, asBytes(input));
-    }
-
-    public byte[] getValues(String key) {
-        return switchStates.get(key);
-    }
-
-    @Override
-    public Dimension getFrameSize() {
-        int height = verticalOverhead + 75;
-        int width = horizontalOverhead;
-        if (height < minHeight) {
-            height = minHeight;
-        }
-        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
-        if (width < minWidth) {
-            width = minWidth;
-        }
-        return new Dimension(width, height);
-    }
-
-    public ButtonGroup getButtonGroup() {
-        return this.buttonGroup;
-    }
-
-    public Map<String, byte[]> getSwitchStates() {
-        return this.switchStates;
-    }
-
-    @Override
-    public void cursorUp() {
-    }
-
-    @Override
-    public void cursorDown() {
-    }
-
-    @Override
-    public void cursorLeft() {
-    }
-
-    @Override
-    public void cursorRight() {
-    }
-
-	@Override
-	public void shiftCursorUp() {
-	}
-
-	@Override
-	public void shiftCursorDown() {
-	}
-
-	@Override
-	public void shiftCursorLeft() {
-	}
-
-	@Override
-	public void shiftCursorRight() {
-	}
-
-    @Override
-    public boolean isLiveDataSupported() {
-        return false;
-    }
-
-    @Override
-    public boolean isButtonSelected() {
-        if (buttonGroup.getSelection() == null) {
-            return false;
-        }
-        else {
-            return true;
-        }
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        // TODO: Validate DTC equals.
-        try {
-            if(null == other) {
-                return false;
-            }
-
-            if(other == this) {
-                return true;
-            }
-
-            if(!(other instanceof TableSwitch)) {
-                return false;
-            }
-
-            TableSwitch otherTable = (TableSwitch)other;
-
-            if( (null == this.getName() && null == otherTable.getName())
-                    || (this.getName().isEmpty() && otherTable.getName().isEmpty()) ) {
-                ;// Skip name compare if name is null or empty.
-            } else if(!this.getName().equalsIgnoreCase(otherTable.getName())) {
-                return false;
-            }
-
-            if(this.getDataSize() != otherTable.getDataSize()) {
-                return false;
-            }
-
-            if(this.getSwitchStates() == otherTable.getSwitchStates()) {
-                return true;
-            }
-
-            // Compare Map Keys
-            Set<String> keys = new HashSet<String>(this.getSwitchStates().keySet());
-            Set<String> otherKeys = new HashSet<String>(otherTable.getSwitchStates().keySet());
-
-            if(keys.size() != otherKeys.size()) {
-                return false;
-            }
-
-            if(!keys.containsAll(otherKeys)) {
-                return false;
-            }
-
-            // Compare Map Values.
-            Set<byte[]> values = new HashSet<byte[]>(this.getSwitchStates().values());
-            Set<byte[]> otherValues = new HashSet<byte[]>(otherTable.getSwitchStates().values());
-            if(values.equals(otherValues)) {
-                return true;
-            }
-
-            // Compare DTC.  Is there a better way to compare the DTC?
-            for(String key : keys) {
-                JRadioButton button = getButtonByText(this.getButtonGroup(), key);
-                JRadioButton otherButton = getButtonByText(otherTable.getButtonGroup(), key);
-
-                if(button.isSelected() != otherButton.isSelected()) {
-                    return false;
-                }
-            }
-
-            return true;
-        } catch(Exception ex) {
-            // TODO: Log Exception.
-            return false;
-        }
-    }
-
-    @Override
-    public void populateCompareValues(Table compareTable) {
-        return; // Do nothing.
-    }
-
-    @Override
-    public void calcCellRanges() {
-        return; // Do nothing.
-    }
-
-    @Override
-    public void drawTable()
-    {
-        return; // Do nothing.
-    }
-
-    @Override
-    public void updateTableLabel() {
-        return; // Do nothing.
-    }
-
-    @Override
-    public void setCurrentScale(Scale curScale) {
-        return; // Do nothing.
-    }
-
-
-    // returns the selected radio button in the specified group
-    private static JRadioButton getSelectedButton(ButtonGroup group) {
-        for (Enumeration<AbstractButton> e = group.getElements(); e.hasMoreElements(); ) {
-            JRadioButton b = (JRadioButton)e.nextElement();
-            if (b.getModel() == group.getSelection()) {
-                return b;
-            }
-        }
-        return null;
-    }
-
-    // Unselects & disables all radio buttons in the specified group
-    private static void setButtonsUnselected(ButtonGroup group) {
-        for (Enumeration<AbstractButton> e = group.getElements(); e.hasMoreElements(); ) {
-            JRadioButton b = (JRadioButton)e.nextElement();
-            b.setSelected(false);
-            b.setEnabled(false);
-        }
-    }
-
-    // returns the radio button based on its display text
-    private static JRadioButton getButtonByText(ButtonGroup group, String text) {
-        for (Enumeration<AbstractButton> e = group.getElements(); e.hasMoreElements(); ) {
-            JRadioButton b = (JRadioButton)e.nextElement();
-            if (b.getText().equalsIgnoreCase(text)) {
-                return b;
-            }
-        }
-        return null;
-    }*/
-
-	public Vector<Scale> getSwitchStates() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 }

--- a/src/main/java/com/romraider/maps/TableSwitch.java
+++ b/src/main/java/com/romraider/maps/TableSwitch.java
@@ -46,8 +46,8 @@ public class TableSwitch extends Table1D {
     
     //TODO: Clean this up!
     @Override
-    public void populateTable(byte[] input, int romRamOffset) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
-        super.populateTable(input,romRamOffset);
+    public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
+        super.populateTable(rom);
         
 	    // Validate the ROM image checksums.
 	    // if the result is >0: position of failed checksum

--- a/src/main/java/com/romraider/maps/TableSwitchView.java
+++ b/src/main/java/com/romraider/maps/TableSwitchView.java
@@ -22,6 +22,7 @@ package com.romraider.maps;
 public class TableSwitchView extends Table1DView {
 	private static final long serialVersionUID = 1L;
 
+	//Same as a Table1DView just hidden data
 	public TableSwitchView(TableSwitch t) {
     	super(t, true);
     }

--- a/src/main/java/com/romraider/maps/TableSwitchView.java
+++ b/src/main/java/com/romraider/maps/TableSwitchView.java
@@ -1,0 +1,28 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2020 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.maps;
+
+public class TableSwitchView extends Table1DView {
+	private static final long serialVersionUID = 1L;
+
+	public TableSwitchView(TableSwitch t) {
+    	super(t, true);
+    }
+}

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -1,0 +1,899 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2021 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.maps;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.io.IOException;
+import java.io.Serializable;
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+import java.util.StringTokenizer;
+import java.util.Vector;
+
+import javax.naming.NameNotFoundException;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.InputMap;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.SwingWorker;
+import org.apache.log4j.Logger;
+
+import com.romraider.Settings;
+import com.romraider.editor.ecu.ECUEditorManager;
+import com.romraider.swing.TableToolBar;
+import com.romraider.util.ByteUtil;
+import com.romraider.util.JEPUtil;
+import com.romraider.util.NumberUtil;
+import com.romraider.util.ResourceUtil;
+import com.romraider.util.SettingsManager;
+
+public abstract class TableView extends JPanel implements Serializable {
+    private static final long serialVersionUID = 6559256489995552645L;
+    protected static final Logger LOGGER = Logger.getLogger(TableView.class);
+    private static final ResourceBundle rb = new ResourceUtil().getBundle(TableView.class.getName());
+
+    protected Table table;
+    protected PresetPanel presetPanel;      
+    protected DataCellView[] data;
+   
+    protected BorderLayout borderLayout = new BorderLayout();
+    protected GridLayout centerLayout = new GridLayout(1, 1, 0, 0);
+    protected JPanel centerPanel = new JPanel(centerLayout);
+    protected JLabel tableLabel;
+    protected int verticalOverhead = 103;
+    protected int horizontalOverhead = 2;
+    protected int cellHeight = (int) getSettings().getCellSize().getHeight();
+    protected int cellWidth = (int) getSettings().getCellSize().getWidth();
+    protected int minHeight = 100;
+    protected int minWidthNoOverlay = 465;
+    protected int minWidthOverlay = 700;
+    protected int highlightX;
+    protected int highlightY;
+    protected boolean highlight = false;
+    protected boolean overlayLog = false;
+
+    protected CopyTableWorker copyTableWorker;
+    protected CopySelectionWorker copySelectionWorker;
+
+    protected Settings.DataType compareValueType = Settings.DataType.BIN;
+    
+    protected TableView(Table table) {
+    	this.table = table;
+    	
+    	//Populate Views from table here
+    	
+        this.setLayout(borderLayout);
+        this.add(centerPanel, BorderLayout.CENTER);
+        centerPanel.setVisible(true);
+             
+        // key binding actions
+        Action rightAction = new AbstractAction() {
+            private static final long serialVersionUID = 1042884198300385041L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cursorRight();
+            }
+        };
+        Action leftAction = new AbstractAction() {
+            private static final long serialVersionUID = -4970441255677214171L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cursorLeft();
+            }
+        };
+        Action downAction = new AbstractAction() {
+            private static final long serialVersionUID = -7898502951121825984L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cursorDown();
+            }
+        };
+        Action upAction = new AbstractAction() {
+            private static final long serialVersionUID = 6937621541727666631L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                cursorUp();
+            }
+        };
+        Action shiftRightAction = new AbstractAction() {
+            private static final long serialVersionUID = 1042888914300385041L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                shiftCursorRight();
+            }
+        };
+        Action shiftLeftAction = new AbstractAction() {
+            private static final long serialVersionUID = -4970441655277214171L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+            	shiftCursorLeft();
+            }
+        };
+        Action shiftDownAction = new AbstractAction() {
+            private static final long serialVersionUID = -7898502951812125984L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+            	shiftCursorDown();
+            }
+        };
+        Action shiftUpAction = new AbstractAction() {
+            private static final long serialVersionUID = 6937621527147666631L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+            	shiftCursorUp();
+            }
+        };
+        Action incCoarseAction = new AbstractAction() {
+            private static final long serialVersionUID = -8308522736529183148L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().incrementCoarse();
+            }
+        };
+        Action decCoarseAction = new AbstractAction() {
+            private static final long serialVersionUID = -7407628920997400915L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().decrementCoarse();
+            }
+        };
+        Action incFineAction = new AbstractAction() {
+            private static final long serialVersionUID = 7261463425941761433L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().incrementFine();
+            }
+        };
+        Action decFineAction = new AbstractAction() {
+            private static final long serialVersionUID = 8929400237520608035L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().decrementFine();
+            }
+        };
+        Action num0Action = new AbstractAction() {
+            private static final long serialVersionUID = -6310984176739090034L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('0');
+            }
+        };
+        Action num1Action = new AbstractAction() {
+            private static final long serialVersionUID = -6187220355403883499L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('1');
+            }
+        };
+        Action num2Action = new AbstractAction() {
+            private static final long serialVersionUID = -8745505977907325720L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('2');
+            }
+        };
+        Action num3Action = new AbstractAction() {
+            private static final long serialVersionUID = 4694872385823448942L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('3');
+            }
+        };
+        Action num4Action = new AbstractAction() {
+            private static final long serialVersionUID = 4005741329254221678L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('4');
+            }
+        };
+        Action num5Action = new AbstractAction() {
+            private static final long serialVersionUID = -5846094949106279884L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('5');
+            }
+        };
+        Action num6Action = new AbstractAction() {
+            private static final long serialVersionUID = -5338656374925334150L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('6');
+            }
+        };
+        Action num7Action = new AbstractAction() {
+            private static final long serialVersionUID = 1959983381590509303L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('7');
+            }
+        };
+        Action num8Action = new AbstractAction() {
+            private static final long serialVersionUID = 7442763278699460648L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('8');
+            }
+        };
+        Action num9Action = new AbstractAction() {
+            private static final long serialVersionUID = 7475171864584215094L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('9');
+            }
+        };
+        Action numPointAction = new AbstractAction() {
+            private static final long serialVersionUID = -4729135055857591830L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('.');
+            }
+        };
+        Action copyAction = new AbstractAction() {
+            private static final long serialVersionUID = -6978981449261938672L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                copySelection();
+            }
+        };
+        Action pasteAction = new AbstractAction() {
+            private static final long serialVersionUID = 2026817603236490899L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                paste();
+            }
+        };
+        Action interpolate = new AbstractAction() {
+            private static final long serialVersionUID = -2357532575392447149L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                table.interpolate();
+            }
+        };
+        Action verticalInterpolate = new AbstractAction() {
+            private static final long serialVersionUID = -2375322575392447149L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                table.verticalInterpolate();
+            }
+        };
+        Action horizontalInterpolate = new AbstractAction() {
+            private static final long serialVersionUID = -6346750245035640773L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                table.horizontalInterpolate();
+            }
+        };
+        Action multiplyAction = new AbstractAction() {
+            private static final long serialVersionUID = -2753212575392447149L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().multiply();
+            }
+        };
+        Action numNegAction = new AbstractAction() {
+            private static final long serialVersionUID = -7532750245035640773L;
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                getToolbar().focusSetValue('-');
+            }
+        };
+
+        // set input mapping
+        InputMap im = getInputMap(WHEN_IN_FOCUSED_WINDOW);
+
+        KeyStroke right = KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, 0);
+        KeyStroke left = KeyStroke.getKeyStroke(KeyEvent.VK_LEFT, 0);
+        KeyStroke up = KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0);
+        KeyStroke down = KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0);
+        KeyStroke shiftRight = KeyStroke.getKeyStroke(KeyEvent.VK_RIGHT, KeyEvent.SHIFT_DOWN_MASK);
+        KeyStroke shiftLeft = KeyStroke.getKeyStroke(KeyEvent.VK_LEFT,  KeyEvent.SHIFT_DOWN_MASK);
+        KeyStroke shiftUp = KeyStroke.getKeyStroke(KeyEvent.VK_UP,  KeyEvent.SHIFT_DOWN_MASK);
+        KeyStroke shiftDown = KeyStroke.getKeyStroke(KeyEvent.VK_DOWN,  KeyEvent.SHIFT_DOWN_MASK);
+        KeyStroke decrement = KeyStroke.getKeyStroke('-');
+        KeyStroke increment = KeyStroke.getKeyStroke('+');
+        KeyStroke decrement2 = KeyStroke.getKeyStroke("control DOWN");
+        KeyStroke increment2 = KeyStroke.getKeyStroke("control UP");
+        KeyStroke decrement3 = KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, KeyEvent.CTRL_DOWN_MASK);
+        KeyStroke increment3 = KeyStroke.getKeyStroke(KeyEvent.VK_PLUS, KeyEvent.CTRL_DOWN_MASK);
+        KeyStroke decrement4 = KeyStroke.getKeyStroke("control shift DOWN");
+        KeyStroke increment4 = KeyStroke.getKeyStroke("control shift UP");
+        KeyStroke num0 = KeyStroke.getKeyStroke('0');
+        KeyStroke num1 = KeyStroke.getKeyStroke('1');
+        KeyStroke num2 = KeyStroke.getKeyStroke('2');
+        KeyStroke num3 = KeyStroke.getKeyStroke('3');
+        KeyStroke num4 = KeyStroke.getKeyStroke('4');
+        KeyStroke num5 = KeyStroke.getKeyStroke('5');
+        KeyStroke num6 = KeyStroke.getKeyStroke('6');
+        KeyStroke num7 = KeyStroke.getKeyStroke('7');
+        KeyStroke num8 = KeyStroke.getKeyStroke('8');
+        KeyStroke num9 = KeyStroke.getKeyStroke('9');
+        KeyStroke mulKey = KeyStroke.getKeyStroke('*');
+        KeyStroke mulKeys = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, KeyEvent.CTRL_DOWN_MASK);
+        KeyStroke numPoint = KeyStroke.getKeyStroke('.');
+        KeyStroke copy = KeyStroke.getKeyStroke("control C");
+        KeyStroke paste = KeyStroke.getKeyStroke("control V");
+        KeyStroke interp = KeyStroke.getKeyStroke("shift I");
+        KeyStroke vinterp = KeyStroke.getKeyStroke("shift V");
+        KeyStroke hinterp = KeyStroke.getKeyStroke("shift H");
+        KeyStroke numNeg = KeyStroke.getKeyStroke('-');
+
+        im.put(right, "right");
+        im.put(left, "left");
+        im.put(up, "up");
+        im.put(down, "down");
+        im.put(shiftRight, "shiftRight");
+        im.put(shiftLeft, "shiftLeft");
+        im.put(shiftUp, "shiftUp");
+        im.put(shiftDown, "shiftDown");
+        im.put(increment, "incCoarseAction");
+        im.put(decrement, "decCoarseAction");
+        im.put(increment2, "incCoarseAction");
+        im.put(decrement2, "decCoarseAction");
+        im.put(increment3, "incFineAction");
+        im.put(decrement3, "decFineAction");
+        im.put(increment4, "incFineAction");
+        im.put(decrement4, "decFineAction");
+        im.put(num0, "num0Action");
+        im.put(num1, "num1Action");
+        im.put(num2, "num2Action");
+        im.put(num3, "num3Action");
+        im.put(num4, "num4Action");
+        im.put(num5, "num5Action");
+        im.put(num6, "num6Action");
+        im.put(num7, "num7Action");
+        im.put(num8, "num8Action");
+        im.put(num9, "num9Action");
+        im.put(numPoint, "numPointAction");
+        im.put(copy, "copyAction");
+        im.put(paste, "pasteAction");
+        im.put(interp, "interpolate");
+        im.put(vinterp, "verticalInterpolate");
+        im.put(hinterp, "horizontalInterpolate");
+        im.put(mulKey, "mulAction");
+        im.put(mulKeys, "mulAction");
+        im.put(numNeg, "numNeg");
+
+        getActionMap().put(im.get(right), rightAction);
+        getActionMap().put(im.get(left), leftAction);
+        getActionMap().put(im.get(up), upAction);
+        getActionMap().put(im.get(down), downAction);
+        getActionMap().put(im.get(shiftRight), shiftRightAction);
+        getActionMap().put(im.get(shiftLeft), shiftLeftAction);
+        getActionMap().put(im.get(shiftUp), shiftUpAction);
+        getActionMap().put(im.get(shiftDown), shiftDownAction);
+        getActionMap().put(im.get(increment), incCoarseAction);
+        getActionMap().put(im.get(decrement), decCoarseAction);
+        getActionMap().put(im.get(increment2), incCoarseAction);
+        getActionMap().put(im.get(decrement2), decCoarseAction);
+        getActionMap().put(im.get(increment3), incFineAction);
+        getActionMap().put(im.get(decrement3), decFineAction);
+        getActionMap().put(im.get(increment4), incFineAction);
+        getActionMap().put(im.get(decrement4), decFineAction);
+        getActionMap().put(im.get(num0), num0Action);
+        getActionMap().put(im.get(num1), num1Action);
+        getActionMap().put(im.get(num2), num2Action);
+        getActionMap().put(im.get(num3), num3Action);
+        getActionMap().put(im.get(num4), num4Action);
+        getActionMap().put(im.get(num5), num5Action);
+        getActionMap().put(im.get(num6), num6Action);
+        getActionMap().put(im.get(num7), num7Action);
+        getActionMap().put(im.get(num8), num8Action);
+        getActionMap().put(im.get(num9), num9Action);
+        getActionMap().put(im.get(numPoint), numPointAction);
+        getActionMap().put(im.get(mulKey), multiplyAction);
+        getActionMap().put(im.get(mulKeys), multiplyAction);
+        getActionMap().put(im.get(copy), copyAction);
+        getActionMap().put(im.get(paste), pasteAction);
+        getActionMap().put(im.get(interp), interpolate);
+        getActionMap().put(im.get(vinterp), verticalInterpolate);
+        getActionMap().put(im.get(hinterp), horizontalInterpolate);
+        getActionMap().put(im.get(numNeg), numNegAction);
+
+        this.setInputMap(WHEN_FOCUSED, im);
+    }
+
+    public DataCellView[] getData() {
+        return data;
+    }
+
+    public void setData(DataCellView[] data) {
+        this.data = data;
+    }
+
+    public DataCellView getDataCell(int location) {
+        return data[location];
+    }
+
+    @Override
+    public String toString() {
+        return table.toString();
+    }
+
+    public void drawTable() {
+    	
+        for(DataCellView cell : data) {
+            if(null != cell) {
+                cell.drawCell();
+            }
+        }
+    }
+
+    public Dimension getFrameSize() {
+        int height = verticalOverhead + cellHeight;
+        int width = horizontalOverhead + data.length * cellWidth;
+        if (height < minHeight) {
+            height = minHeight;
+        }
+        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
+        if (width < minWidth) {
+            width = minWidth;
+        }
+        return new Dimension(width, height);
+    }
+
+    public void increment(double increment) {
+        if (!locked && !(userLevel > getSettings().getUserLevel())) {
+            for (DataCellView cell : data) {
+                if (cell.isSelected()) {
+                    cell.getDataCell().increment(increment);
+                }
+            }
+        } else if (userLevel > getSettings().getUserLevel()) {
+            JOptionPane.showMessageDialog(this, MessageFormat.format(
+                    rb.getString("USERLVLTOLOW"), userLevel),
+                    rb.getString("TBLNOTMODIFY"),
+                    JOptionPane.INFORMATION_MESSAGE);
+        }
+    }
+
+    public void multiply(double factor) {
+    	
+        if (!locked && !(userLevel > getSettings().getUserLevel())) {
+            for (DataCellView cell : data) {
+                if (cell.isSelected()) {
+                	
+                	//Use raw or real value, depending on view settings
+                	if(getCurrentScale().getName().equals("Raw Value"))
+                		cell.getDataCell().multiplyRaw(factor);                	
+                	else 
+                		cell.getDataCell().multiply(factor);               	
+                }
+            }
+        } else if (userLevel > getSettings().getUserLevel()) {
+            JOptionPane.showMessageDialog(this, MessageFormat.format(
+                    rb.getString("USERLVLTOLOW"), userLevel),
+                    rb.getString("TBLNOTMODIFY"),
+                    JOptionPane.INFORMATION_MESSAGE);
+        }
+    }
+
+    public void setRealValue(String realValue) {
+        if (!locked && userLevel <= getSettings().getUserLevel()) {
+            for(DataCellView cell : data) {
+                if (cell.isSelected()) {
+                    cell.getDataCell().setRealValue(realValue);
+                }
+            }
+        } else if (userLevel > getSettings().getUserLevel()) {
+            JOptionPane.showMessageDialog(this, MessageFormat.format(
+                    rb.getString("USERLVLTOLOW"), userLevel),
+                    rb.getString("TBLNOTMODIFY"),
+                    JOptionPane.INFORMATION_MESSAGE);
+        }
+    }
+
+    public void clearSelection() {
+        for (DataCellView cell : data) {
+                cell.getDataCell().setSelected(false);
+            }
+    }
+
+    public void startHighlight(int x, int y) {
+        this.highlightY = y;
+        this.highlightX = x;
+        highlight = true;
+        highlight(x, y);
+    }
+
+    public void highlight(int x, int y) {
+        if (highlight) {
+            for (int i = 0; i < data.length; i++) {
+                if ((i >= highlightY && i <= y) || (i <= highlightY && i >= y)) {
+                    data[i].setHighlighted(true);
+                } else {
+                    data[i].setHighlighted(false);
+                }
+            }
+        }
+    }
+
+    public void stopHighlight() {
+        highlight = false;
+        // loop through, selected and un-highlight
+        for (DataCellView cell : data) {
+            if (cell.isHighlighted()) {
+                cell.setHighlighted(false);
+                cell.getDataCell().setSelected(true);
+            }
+        }
+    }
+
+    public abstract void cursorUp();
+
+    public abstract void cursorDown();
+
+    public abstract void cursorLeft();
+
+    public abstract void cursorRight();
+
+    public abstract void shiftCursorUp();
+
+    public abstract void shiftCursorDown();
+
+    public abstract void shiftCursorLeft();
+
+    public abstract void shiftCursorRight();
+
+  
+    abstract public byte[] saveFile(byte[] binData);
+       
+    @Override
+    public void addKeyListener(KeyListener listener) {
+        super.addKeyListener(listener);
+        for (DataCellView cell : data) {
+            for (int z = 0; z < table.getStorageType(); z++) {
+                cell.addKeyListener(listener);
+            }
+        }
+    }
+
+    public void selectCellAt(int y) {
+        if(y >= 0 && y < data.length) {
+            clearSelection();
+            data[y].getDataCell().setSelected(true);
+            highlightY = y;
+            ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
+        }
+    }
+
+    public void selectCellAtWithoutClear(int y) {
+        if(y >= 0 && y < data.length) {
+            data[y].getDataCell().setSelected(true);
+            highlightY = y;
+            ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
+        }
+    }
+
+    public void copySelection() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+
+        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        copySelectionWorker = new CopySelectionWorker(table);
+        copySelectionWorker.execute();
+    }
+
+    public StringBuffer getTableAsString() {
+        StringBuffer output = new StringBuffer(Settings.BLANK);
+        for (int i = 0; i < data.length; i++) {
+            if (overlayLog) {
+                output.append(data[i].getCellText());
+            }
+            else {
+            	if(data[i]!= null)
+            		output.append(NumberUtil.stringValue(data[i].getDataCell().getRealValue()));
+            }
+            if (i < data.length - 1) {
+                output.append(Settings.TAB);
+            }
+        }
+        return output;
+    }
+
+    public void copyTable() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        }
+        ECUEditorManager.getECUEditor().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        copyTableWorker = new CopyTableWorker(table);
+        copyTableWorker.execute();
+    }
+
+    public String getCellAsString(int index) {
+        return data[index].getText();
+    }
+
+    public void pasteValues(String[] input) {
+        //set real values
+        for (int i = 0; i < input.length; i++) {
+            try {
+                Double.parseDouble(input[i]);
+                data[i].getDataCell().setRealValue(input[i]);
+            } catch (NumberFormatException ex) { /* not a number, do nothing */ }
+        }
+    }
+
+    public void paste() {
+        // TODO: This sounds like desearialize.
+        if (!table.isStaticDataTable()) {
+            StringTokenizer st = new StringTokenizer(Settings.BLANK);
+            try {
+                String input = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
+                st = new StringTokenizer(input, Table.ST_DELIMITER);
+            } catch (UnsupportedFlavorException ex) { /* wrong paste type -- do nothing */
+            } catch (IOException ex) {
+            }
+    
+            String pasteType = st.nextToken();
+    
+            if ("[Table1D]".equalsIgnoreCase(pasteType)) { // copied entire table
+                int i = 0;
+                while (st.hasMoreTokens()) {
+                    String currentToken = st.nextToken();
+                    try {
+                        if (!data[i].getText().equalsIgnoreCase(currentToken)) {
+                            data[i].getDataCell().setRealValue(currentToken);
+                        }
+                    } catch (ArrayIndexOutOfBoundsException ex) { /* table larger than target, ignore*/ }
+                    i++;
+                }
+            } else if ("[Selection1D]".equalsIgnoreCase(pasteType)) { // copied selection
+                if (data[highlightY].getDataCell().isSelected()) {
+                    int i = 0;
+                    while (st.hasMoreTokens()) {
+                        String currentToken = st.nextToken();
+                        try {
+                            if (!data[highlightY + i].getText().equalsIgnoreCase(currentToken)) {
+                                data[highlightY + i].getDataCell().setRealValue(currentToken);
+                            }
+                        } catch (ArrayIndexOutOfBoundsException ex) { /* paste larger than target, ignore */ }
+                        i++;
+                    }
+                }
+            }
+        }
+    }
+
+    public void setCompareValueType(Settings.DataType compareValueType) {
+        this.compareValueType = compareValueType;
+        drawTable();
+    }
+
+    public Settings.DataType getCompareValueType() {
+        return this.compareValueType;
+    }
+
+    
+    public Settings getSettings()
+    {
+        return SettingsManager.getSettings();
+    }
+
+    public TableToolBar getToolbar()
+    {
+        return ECUEditorManager.getECUEditor().getTableToolBar();
+    }
+
+
+    public void setOverlayLog(boolean overlayLog) {
+        this.overlayLog = overlayLog;
+    }
+
+    public boolean getOverlayLog()
+    {
+        return this.overlayLog;
+    }
+
+
+    public void highlightLiveData(String liveVal) {
+        if (getOverlayLog()) {
+            double liveValue = 0.0;
+            try {
+            	liveValue = NumberUtil.doubleValue(liveVal);
+            } catch (Exception ex) {
+            	LOGGER.error("Table - live data highlight parsing error for value: " + liveVal);
+            	return;
+            }
+
+            int startIdx = data.length;
+            for (int i = 0; i < data.length; i++) {
+                double currentValue = data[i].getDataCell().getRealValue();
+                if (liveValue == currentValue) {
+                    startIdx = i;
+                    break;
+                } else if (liveValue < currentValue){
+                    startIdx = i-1;
+                    break;
+                }
+            }
+
+            setLiveDataIndex(startIdx);
+            DataCellView cell = data[getLiveDataIndex()];
+            cell.setPreviousLiveDataTrace(false);
+            cell.setLiveDataTrace(true);
+            cell.getDataCell().setLiveDataTraceValue(liveVal);
+            getToolbar().setLiveDataValue(liveVal);
+        }
+    }
+
+    public void updateLiveDataHighlight() {
+        if (getOverlayLog()) {
+            data[getPreviousLiveDataIndex()].setPreviousLiveDataTrace(true);
+            data[getLiveDataIndex()].setPreviousLiveDataTrace(false);
+            data[getLiveDataIndex()].setLiveDataTrace(true);
+        }
+    }
+
+    public void clearLiveDataTrace() {
+        for (DataCellView cell : data) {
+            cell.setLiveDataTrace(false);
+            cell.setPreviousLiveDataTrace(false);
+        }
+    }
+
+
+    public void updateTableLabel() {
+        if(null == name || name.isEmpty()) {
+            ;// Do not update label.
+        } else if(null == getCurrentScale () || "0x" == getCurrentScale().getUnit()) {
+            // static or no scale exists.
+            tableLabel.setText(getName());
+        } else {
+            tableLabel.setText(getName() + " (" + getCurrentScale().getUnit() + ")");
+        }
+    }
+
+class CopySelectionWorker extends SwingWorker<Void, Void> {
+    Table table;
+
+    public CopySelectionWorker(Table table) {
+        this.table = table;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        // find bounds of selection
+        // coords[0] = x min, y min, x max, y max
+        String output = "[Selection1D]" + Settings.NEW_LINE;
+        boolean copy = false;
+        int[] coords = new int[2];
+        coords[0] = table.getDataSize();
+
+        for (int i = 0; i < table.getDataSize(); i++) {
+            if (table.getData()[i].isSelected()) {
+                if (i < coords[0]) {
+                    coords[0] = i;
+                    copy = true;
+                }
+                if (i > coords[1]) {
+                    coords[1] = i;
+                    copy = true;
+                }
+            }
+        }
+        //make a string of the selection
+        for (int i = coords[0]; i <= coords[1]; i++) {
+            if (table.getData()[i].isSelected()) {
+                output = output + NumberUtil.stringValue(table.getData()[i].getDataCell().getRealValue());
+            } else {
+                output = output + "x"; // x represents non-selected cell
+            }
+            if (i < coords[1]) {
+                output = output + "\t";
+            }
+        }
+        //copy to clipboard
+        if (copy) {
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(output), null);
+        }
+        return null;
+    }
+
+    @Override
+    public void done() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(null);
+        }
+        table.setCursor(null);
+        ECUEditorManager.getECUEditor().setCursor(null);
+    }
+}
+
+class CopyTableWorker extends SwingWorker<Void, Void> {
+    Table table;
+
+    public CopyTableWorker(Table table) {
+        this.table = table;
+    }
+
+    @Override
+    protected Void doInBackground() throws Exception {
+        String tableHeader = table.getSettings().getTableHeader();
+        StringBuffer output = new StringBuffer(tableHeader);
+        output.append(table.getTableAsString());
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
+        return null;
+    }
+
+    @Override
+    public void done() {
+        Window ancestorWindow = SwingUtilities.getWindowAncestor(table);
+        if(null != ancestorWindow) {
+            ancestorWindow.setCursor(null);
+        }
+        table.setCursor(null);
+        ECUEditorManager.getECUEditor().setCursor(null);
+    }
+}

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -321,45 +321,67 @@ public abstract class TableView extends JPanel implements Serializable {
 				}
             }
         };
-        Action interpolate = new AbstractAction() {
+     
+        class InterpolateAction extends AbstractAction{
             private static final long serialVersionUID = -2357532575392447149L;
-
+            Table t;
+            
+            public InterpolateAction(Table t) {
+            	this.t = t;
+            }
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                	table.interpolate();
+                	t.interpolate();
 			} catch (UserLevelException e1) {
 				showInvalidUserLevelPopup(e1);
 			}
             }
         };
-        Action verticalInterpolate = new AbstractAction() {
+        
+        Action interpolate = new InterpolateAction(table);
+        
+        class VerticalInterpolateAction extends  AbstractAction {
             private static final long serialVersionUID = -2375322575392447149L;
-
+            Table t;
+            
+            public VerticalInterpolateAction(Table t) {
+            	this.t = t;
+            }
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                	table.verticalInterpolate();
-			} catch (UserLevelException e1) {
-				showInvalidUserLevelPopup(e1);
-			}
+                	t.verticalInterpolate();
+				} catch (UserLevelException e1) {
+					showInvalidUserLevelPopup(e1);
+				}
             }
         };
-        Action horizontalInterpolate = new AbstractAction() {
+        
+        Action verticalInterpolate = new VerticalInterpolateAction(table);
+
+        class HorizontalInterpolateAction extends AbstractAction {
             private static final long serialVersionUID = -6346750245035640773L;
-
+            Table t;
+                    
+            public HorizontalInterpolateAction(Table t) {
+            	this.t = t;
+            }
+            
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                	table.horizontalInterpolate();
-			} catch (UserLevelException e1) {
-				showInvalidUserLevelPopup(e1);
-			}
+                	t.horizontalInterpolate();
+				} catch (UserLevelException e1) {
+					showInvalidUserLevelPopup(e1);
+				}
             }
         };
-        Action multiplyAction = new AbstractAction() {
-            private static final long serialVersionUID = -2753212575392447149L;
-
+        
+        Action horizontalInterpolate = new HorizontalInterpolateAction(table);
+        		
+        class MultiplyAction extends AbstractAction {
+            private static final long serialVersionUID = -2753212575392447149L;                       
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
@@ -369,6 +391,9 @@ public abstract class TableView extends JPanel implements Serializable {
     			}
             }
         };
+        
+        Action multiplyAction = new MultiplyAction();
+        
         Action numNegAction = new AbstractAction() {
             private static final long serialVersionUID = -7532750245035640773L;
 

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -91,7 +91,6 @@ public abstract class TableView extends JPanel implements Serializable {
     protected CopySelectionWorker copySelectionWorker;  
     protected Settings.CompareDisplay compareDisplay = Settings.CompareDisplay.ABSOLUTE;
 
-
     protected TableView(Table table) {    	
     	this.table = table;
     	table.setTableView(this);
@@ -574,10 +573,13 @@ public abstract class TableView extends JPanel implements Serializable {
     }
     
 
+    protected void addPresetPanel(PresetManager m) {
+    	 presetPanel = new PresetPanel(this, m);
+    }
     
     public void populateTableVisual() {
     	//Populate Views from table here
-    	if(getTable().presetManager != null) presetPanel = new PresetPanel(this, getTable().presetManager);
+    	if(getTable().presetManager != null) addPresetPanel(getTable().presetManager);
     	
     	if(!isHidden()) {
 	    	data = new DataCellView[table.getDataSize()];

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -52,6 +52,7 @@ import org.apache.log4j.Logger;
 
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
+import com.romraider.swing.TableFrame;
 import com.romraider.swing.TableToolBar;
 import com.romraider.util.NumberUtil;
 import com.romraider.util.ResourceUtil;
@@ -63,8 +64,9 @@ public abstract class TableView extends JPanel implements Serializable {
     private static final ResourceBundle rb = new ResourceUtil().getBundle(TableView.class.getName());
 
     protected Table table;
-    protected PresetPanel presetPanel;      
+    protected PresetPanel presetPanel;   
     protected DataCellView[] data;
+    protected TableFrame frame;
     
     protected BorderLayout borderLayout = new BorderLayout();
     protected GridLayout centerLayout = new GridLayout(1, 1, 0, 0);
@@ -89,8 +91,8 @@ public abstract class TableView extends JPanel implements Serializable {
     protected CopySelectionWorker copySelectionWorker;  
     protected Settings.CompareDisplay compareDisplay = Settings.CompareDisplay.ABSOLUTE;
 
-    
-    protected TableView(Table table) {
+    protected TableView(Table table, TableFrame frame) {
+    	this.frame = frame;
     	this.table = table;
     	table.setTableView(this);
     	
@@ -170,7 +172,11 @@ public abstract class TableView extends JPanel implements Serializable {
 
             @Override
             public void actionPerformed(ActionEvent e) {
+                try {
                 getToolbar().incrementCoarse();
+			} catch (UserLevelException e1) {
+				showInvalidUserLevelPopup(e1);
+			}
             }
         };
         Action decCoarseAction = new AbstractAction() {
@@ -178,7 +184,11 @@ public abstract class TableView extends JPanel implements Serializable {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                getToolbar().decrementCoarse();
+                try {
+					getToolbar().decrementCoarse();
+				} catch (UserLevelException e1) {
+					showInvalidUserLevelPopup(e1);
+				}
             }
         };
         Action incFineAction = new AbstractAction() {
@@ -186,7 +196,11 @@ public abstract class TableView extends JPanel implements Serializable {
 
             @Override
             public void actionPerformed(ActionEvent e) {
+                try {
                 getToolbar().incrementFine();
+			} catch (UserLevelException e1) {
+				showInvalidUserLevelPopup(e1);
+			}
             }
         };
         Action decFineAction = new AbstractAction() {
@@ -194,7 +208,11 @@ public abstract class TableView extends JPanel implements Serializable {
 
             @Override
             public void actionPerformed(ActionEvent e) {
+                try {
                 getToolbar().decrementFine();
+			} catch (UserLevelException e1) {
+				showInvalidUserLevelPopup(e1);
+			}
             }
         };
         Action num0Action = new AbstractAction() {
@@ -346,7 +364,11 @@ public abstract class TableView extends JPanel implements Serializable {
 
             @Override
             public void actionPerformed(ActionEvent e) {
+                try {
                 getToolbar().multiply();
+    			} catch (UserLevelException e1) {
+    				showInvalidUserLevelPopup(e1);
+    			}
             }
         };
         Action numNegAction = new AbstractAction() {
@@ -470,6 +492,10 @@ public abstract class TableView extends JPanel implements Serializable {
         getActionMap().put(im.get(numNeg), numNegAction);
 
         this.setInputMap(WHEN_FOCUSED, im);
+    }
+      
+    public TableFrame getFrame() {
+    	return frame;
     }
     
     public Table getTable() {
@@ -649,25 +675,7 @@ public abstract class TableView extends JPanel implements Serializable {
             ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
         }
     }
-    
-    public StringBuffer getTableAsString() {
-        StringBuffer output = new StringBuffer(Settings.BLANK);
-        for (int i = 0; i < data.length; i++) {
-
-            if (overlayLog) {
-                output.append(data[i].getCellText());
-            }
-            else {
-            	if(data[i]!= null)
-            		output.append(NumberUtil.stringValue(data[i].getDataCell().getRealValue()));
-            }
-            if (i < data.length - 1) {
-                output.append(Settings.TAB);
-            }
-        }
-        return output;
-    }
-    
+      
     public void copySelection() {
         Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
 
@@ -959,7 +967,7 @@ class CopyTableWorker extends SwingWorker<Void, Void> {
     protected Void doInBackground() throws Exception {
         String tableHeader = table.getSettings().getTableHeader();
         StringBuffer output = new StringBuffer(tableHeader);
-        output.append(getTableAsString());
+        output.append(table.getTableAsString());
         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(String.valueOf(output)), null);
         return null;
     }

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -66,7 +66,6 @@ public abstract class TableView extends JPanel implements Serializable {
     protected Table table;
     protected PresetPanel presetPanel;   
     protected DataCellView[] data;
-    protected TableFrame frame;
     
     protected BorderLayout borderLayout = new BorderLayout();
     protected GridLayout centerLayout = new GridLayout(1, 1, 0, 0);
@@ -91,17 +90,14 @@ public abstract class TableView extends JPanel implements Serializable {
     protected CopySelectionWorker copySelectionWorker;  
     protected Settings.CompareDisplay compareDisplay = Settings.CompareDisplay.ABSOLUTE;
 
-    protected TableView(Table table, TableFrame frame) {
-    	this.frame = frame;
+    protected TableView(Table table) {    	
     	this.table = table;
     	table.setTableView(this);
-    	
-    	//Populate Views from table here
-    	
+    	   	
         this.setLayout(borderLayout);
         this.add(centerPanel, BorderLayout.CENTER);
         centerPanel.setVisible(true);
-             
+                    
         // key binding actions
         Action rightAction = new AbstractAction() {
             private static final long serialVersionUID = 1042884198300385041L;
@@ -495,7 +491,7 @@ public abstract class TableView extends JPanel implements Serializable {
     }
       
     public TableFrame getFrame() {
-    	return frame;
+    	return table.getTableFrame();
     }
     
     public Table getTable() {
@@ -520,12 +516,13 @@ public abstract class TableView extends JPanel implements Serializable {
     }
      
     public void drawTable() {
-    	
-        for(DataCellView cell : data) {
-            if(null != cell) {
-                cell.drawCell();
-            }
-        }
+    	if(data!=null) {
+	        for(DataCellView cell : data) {
+	            if(null != cell) {
+	                cell.drawCell();
+	            }
+	        }
+    	}
     }
     
     public void verticalInterpolate() throws UserLevelException{
@@ -542,7 +539,14 @@ public abstract class TableView extends JPanel implements Serializable {
         return (x1 == x2) ? 0.0 : (y1 + (x - x1) * (y2 - y1) / (x2 - x1));
     }
     
-    public abstract void populateTable(byte[] input, int romRamOffset);
+    public void populateTableVisual() {
+    	//Populate Views from table here
+    	data = new DataCellView[table.getDataSize()];
+
+    	for(int i= 0; i < table.getDataSize(); i++) {
+    		data[i] = new DataCellView(table.getData()[i], this);		
+    	}
+    }
     
     public Dimension getFrameSize() {
         int height = verticalOverhead + cellHeight;
@@ -561,6 +565,11 @@ public abstract class TableView extends JPanel implements Serializable {
         for (DataCellView cell : data) {
                 cell.setSelected(false);
             }
+    }
+    
+    @Override
+    public void repaint() {
+    	drawTable();
     }
 
     public void startHighlight(int x, int y) {

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -67,6 +67,7 @@ public abstract class TableView extends JPanel implements Serializable {
     protected PresetPanel presetPanel;   
     protected DataCellView[] data;
     
+    protected boolean hide; //Hide the actual data
     protected BorderLayout borderLayout = new BorderLayout();
     protected GridLayout centerLayout = new GridLayout(1, 1, 0, 0);
     protected JPanel centerPanel = new JPanel(centerLayout);
@@ -89,6 +90,7 @@ public abstract class TableView extends JPanel implements Serializable {
     protected CopyTableWorker copyTableWorker;
     protected CopySelectionWorker copySelectionWorker;  
     protected Settings.CompareDisplay compareDisplay = Settings.CompareDisplay.ABSOLUTE;
+
 
     protected TableView(Table table) {    	
     	this.table = table;
@@ -513,14 +515,31 @@ public abstract class TableView extends JPanel implements Serializable {
     public DataCellView getDataCell(int location) {
         return data[location];
     }
-
+    
+    public boolean isHidden() {
+    	return hide;
+    }
+    
+    public void setHidden(boolean b) {
+    	this.hide = b;
+    	
+    	if(this.hide!=b) {
+    		if(!b) {
+    			data = null;
+    		}
+    		else {
+    			populateTableVisual();
+    		}
+    	}
+    }
+    
     @Override
     public String toString() {
         return table.toString();
     }
      
     public void drawTable() {
-    	if(data!=null) {
+    	if(data!=null && !isHidden()) {
 	        for(DataCellView cell : data) {
 	            if(null != cell) {
 	                cell.drawCell();
@@ -545,10 +564,14 @@ public abstract class TableView extends JPanel implements Serializable {
     
     public void populateTableVisual() {
     	//Populate Views from table here
-    	data = new DataCellView[table.getDataSize()];
-
-    	for(int i= 0; i < table.getDataSize(); i++) {
-    		data[i] = new DataCellView(table.getData()[i], this);		
+    	if(getTable().presetManager != null) presetPanel = new PresetPanel(this, getTable().presetManager);
+    	
+    	if(!isHidden()) {
+	    	data = new DataCellView[table.getDataSize()];
+	
+	    	for(int i= 0; i < table.getDataSize(); i++) {
+	    		data[i] = new DataCellView(table.getData()[i], this);
+	    	}
     	}
     }
     

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -484,14 +484,16 @@ public abstract class TableView extends JPanel implements Serializable {
             }
         }
     }
-
+    
+    public abstract void populateTable(byte[] input, int romRamOffset);
+    
     public Dimension getFrameSize() {
         int height = verticalOverhead + cellHeight;
         int width = horizontalOverhead + data.length * cellWidth;
         if (height < minHeight) {
             height = minHeight;
         }
-        int minWidth = isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
+        int minWidth = table.isLiveDataSupported() ? minWidthOverlay : minWidthNoOverlay;
         if (width < minWidth) {
             width = minWidth;
         }
@@ -734,7 +736,7 @@ public abstract class TableView extends JPanel implements Serializable {
         }
     }
     
-    public abstract boolean isLiveDataSupported();
+
     
     public void highlightLiveData(String liveVal) {
         if (getOverlayLog()) {

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -494,6 +494,10 @@ public abstract class TableView extends JPanel implements Serializable {
     	return table.getTableFrame();
     }
     
+    public void setTable(Table t) {
+    	 this.table = t;
+    }
+    
     public Table getTable() {
     	return this.table;
     }
@@ -565,11 +569,6 @@ public abstract class TableView extends JPanel implements Serializable {
         for (DataCellView cell : data) {
                 cell.setSelected(false);
             }
-    }
-    
-    @Override
-    public void repaint() {
-    	drawTable();
     }
 
     public void startHighlight(int x, int y) {
@@ -878,6 +877,10 @@ public abstract class TableView extends JPanel implements Serializable {
         } else {
             tableLabel.setText(getName() + " (" + table.getCurrentScale().getUnit() + ")");
         }
+    }
+    
+    public String getName() {
+    	return table.getName();
     }
     
     public static void showBadScalePopup(Table table, Scale scale) {

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -327,7 +327,7 @@ public abstract class TableView extends JPanel implements Serializable {
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                interpolate();
+                	table.interpolate();
 			} catch (UserLevelException e1) {
 				showInvalidUserLevelPopup(e1);
 			}
@@ -339,7 +339,7 @@ public abstract class TableView extends JPanel implements Serializable {
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                verticalInterpolate();
+                	table.verticalInterpolate();
 			} catch (UserLevelException e1) {
 				showInvalidUserLevelPopup(e1);
 			}
@@ -351,7 +351,7 @@ public abstract class TableView extends JPanel implements Serializable {
             @Override
             public void actionPerformed(ActionEvent e) {
                 try {
-                horizontalInterpolate();
+                	table.horizontalInterpolate();
 			} catch (UserLevelException e1) {
 				showInvalidUserLevelPopup(e1);
 			}
@@ -548,19 +548,7 @@ public abstract class TableView extends JPanel implements Serializable {
     	}
     }
     
-    public void verticalInterpolate() throws UserLevelException{
-    }
 
-    public void horizontalInterpolate() throws UserLevelException {
-    }
-
-    public void interpolate() throws UserLevelException {
-        horizontalInterpolate();
-    }
-    
-    public double linearInterpolation(double x, double x1, double x2, double y1, double y2) {
-        return (x1 == x2) ? 0.0 : (y1 + (x - x1) * (y2 - y1) / (x2 - x1));
-    }
     
     public void populateTableVisual() {
     	//Populate Views from table here
@@ -588,11 +576,7 @@ public abstract class TableView extends JPanel implements Serializable {
         return new Dimension(width, height);
     }
 
-    public void clearSelection() {
-        for (DataCellView cell : data) {
-                cell.setSelected(false);
-            }
-    }
+
 
     public void startHighlight(int x, int y) {
         this.highlightY = y;
@@ -619,7 +603,7 @@ public abstract class TableView extends JPanel implements Serializable {
         for (DataCellView cell : data) {
             if (cell.isHighlighted()) {
                 cell.setHighlighted(false);
-                cell.setSelected(true);
+                cell.getDataCell().setSelected(true);
             }
         }
     }
@@ -655,31 +639,7 @@ public abstract class TableView extends JPanel implements Serializable {
                 rb.getString("TBLNOTMODIFY"),
                 JOptionPane.INFORMATION_MESSAGE);
     }
-   
-    public void increment(double increment) throws UserLevelException {
-	    for (DataCellView cell : data) {
-	        if (cell.isSelected()) {
-	            cell.getDataCell().increment(increment);
-	        }
-	    }
-    }
-
-    public void multiply(double factor) throws UserLevelException{  	
-    	for (DataCellView cell : data) {
-	        if (cell.isSelected()) {
-	        	cell.getDataCell().multiply(factor);               	
-            }
-         }
-    }
-
-    public void setRealValue(String realValue) throws UserLevelException {
-        for(DataCellView cell : data) {
-            if (cell.isSelected()) {
-                cell.getDataCell().setRealValue(realValue);
-            }
-        }
-    }
-    
+      
     @Override
     public void addKeyListener(KeyListener listener) {
         super.addKeyListener(listener);
@@ -689,24 +649,7 @@ public abstract class TableView extends JPanel implements Serializable {
             }
         }
     }
-
-    public void selectCellAt(int y) {
-        if(y >= 0 && y < data.length) {
-            clearSelection();
-            data[y].setSelected(true);
-            highlightY = y;
-            ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
-        }
-    }
-
-    public void selectCellAtWithoutClear(int y) {
-        if(y >= 0 && y < data.length) {
-            data[y].setSelected(true);
-            highlightY = y;
-            ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(table);
-        }
-    }
-      
+    
     public void copySelection() {
         Window ancestorWindow = SwingUtilities.getWindowAncestor(this);
 

--- a/src/main/java/com/romraider/maps/UserLevelException.java
+++ b/src/main/java/com/romraider/maps/UserLevelException.java
@@ -1,6 +1,7 @@
 package com.romraider.maps;
 
 public class UserLevelException extends Exception {
+	private static final long serialVersionUID = 1L;
 	private int level = -1;
 	
 	public UserLevelException(int level) {

--- a/src/main/java/com/romraider/maps/UserLevelException.java
+++ b/src/main/java/com/romraider/maps/UserLevelException.java
@@ -1,0 +1,13 @@
+package com.romraider.maps;
+
+public class UserLevelException extends Exception {
+	private int level = -1;
+	
+	public UserLevelException(int level) {
+		this.level = level;
+	}
+	
+	public int getLevel() {
+		return level;
+	}
+}

--- a/src/main/java/com/romraider/swing/CompareImagesForm.java
+++ b/src/main/java/com/romraider/swing/CompareImagesForm.java
@@ -157,7 +157,7 @@ public class CompareImagesForm extends JFrame implements ActionListener {
     private TableTreeNode findAndShowTable(Rom rom, String tableName) {
         for(TableTreeNode node : rom.getTableNodes()) {
             if(node != null && node.getTable().getName().equals(tableName)){
-                ECUEditorManager.getECUEditor().displayTable(node.getFrame());
+                ECUEditorManager.getECUEditor().displayTable(node);
                 return node;
             }
         }

--- a/src/main/java/com/romraider/swing/ECUEditorMenuBar.java
+++ b/src/main/java/com/romraider/swing/ECUEditorMenuBar.java
@@ -511,7 +511,7 @@ public class ECUEditorMenuBar extends JMenuBar implements ActionListener {
     }
 
     public void saveImage(boolean quickSave) throws Exception {
-        Rom lastSelectedRom = ECUEditorManager.getECUEditor().getLastSelectedRom();
+    	Rom lastSelectedRom = ECUEditorManager.getECUEditor().getLastSelectedRom();
         if (lastSelectedRom != null) {
         	
         	File selectedFile = lastSelectedRom.getFullFileName();
@@ -526,10 +526,12 @@ public class ECUEditorMenuBar extends JMenuBar implements ActionListener {
 
     private File getImageOutputFile() throws Exception {
         ECUEditor parent = ECUEditorManager.getECUEditor();
+       
         JFileChooser fc = new JFileChooser(SettingsManager.getSettings().getLastImageDir());
         fc.setFileFilter(new ECUImageFilter());
         if (fc.showSaveDialog(parent) == JFileChooser.APPROVE_OPTION) {
             File selectedFile = fc.getSelectedFile();
+            
             if (selectedFile.exists()) {
                 int option = showConfirmDialog(parent,
                         MessageFormat.format(
@@ -541,6 +543,16 @@ public class ECUEditorMenuBar extends JMenuBar implements ActionListener {
                     return null;
                 }
             }
+            
+            //Append suffix if user didnt set anything
+            if(!selectedFile.getName().contains(".")) {
+            	Rom lastSelectedRom = ECUEditorManager.getECUEditor().getLastSelectedRom();
+            	String lastFile = lastSelectedRom.getFileName().toLowerCase();
+            	String format = ".bin";
+            	if(lastFile.endsWith(".hex")) format=".hex";
+            	selectedFile = new File(selectedFile + format);
+            }
+            
             return selectedFile;
         }
         return null;

--- a/src/main/java/com/romraider/swing/ECUEditorMenuBar.java
+++ b/src/main/java/com/romraider/swing/ECUEditorMenuBar.java
@@ -532,6 +532,15 @@ public class ECUEditorMenuBar extends JMenuBar implements ActionListener {
         if (fc.showSaveDialog(parent) == JFileChooser.APPROVE_OPTION) {
             File selectedFile = fc.getSelectedFile();
             
+            //Append suffix if user didn't set anything
+            if(!selectedFile.getName().contains(".")) {
+            	Rom lastSelectedRom = ECUEditorManager.getECUEditor().getLastSelectedRom();
+            	String lastFile = lastSelectedRom.getFileName().toLowerCase();
+            	String format = ".bin";
+            	if(lastFile.endsWith(".hex")) format=".hex";
+            	selectedFile = new File(selectedFile + format);
+            }
+                      
             if (selectedFile.exists()) {
                 int option = showConfirmDialog(parent,
                         MessageFormat.format(
@@ -543,16 +552,7 @@ public class ECUEditorMenuBar extends JMenuBar implements ActionListener {
                     return null;
                 }
             }
-            
-            //Append suffix if user didnt set anything
-            if(!selectedFile.getName().contains(".")) {
-            	Rom lastSelectedRom = ECUEditorManager.getECUEditor().getLastSelectedRom();
-            	String lastFile = lastSelectedRom.getFileName().toLowerCase();
-            	String format = ".bin";
-            	if(lastFile.endsWith(".hex")) format=".hex";
-            	selectedFile = new File(selectedFile + format);
-            }
-            
+                     
             return selectedFile;
         }
         return null;

--- a/src/main/java/com/romraider/swing/JTableChooser.java
+++ b/src/main/java/com/romraider/swing/JTableChooser.java
@@ -101,7 +101,7 @@ public class JTableChooser extends JOptionPane implements MouseListener {
 
         Object[] values = {rb.getString("COMPARE"), rb.getString("CANCEL")};
 
-        if ((showOptionDialog(SwingUtilities.windowForComponent(targetTable),
+        if ((showOptionDialog(SwingUtilities.windowForComponent(targetTable.getTableView()),
                 displayPanel,
                 rb.getString("SELECT"), JOptionPane.DEFAULT_OPTION,
                 JOptionPane.PLAIN_MESSAGE, null, values, values[0]) == 0

--- a/src/main/java/com/romraider/swing/RomCellRenderer.java
+++ b/src/main/java/com/romraider/swing/RomCellRenderer.java
@@ -100,7 +100,7 @@ public class RomCellRenderer implements TreeCellRenderer {
             returnValue = renderer;
         } else if (value != null && value instanceof TableTreeNode) {
 
-            Table table = ((TableFrame)((DefaultMutableTreeNode) value).getUserObject()).getTable();
+            Table table = (Table) (((TableTreeNode)(value)).getUserObject());
             JPanel renderer = new JPanel(new GridLayout(1, 1));
             renderer.setBorder(createLineBorder(Color.WHITE));
             JLabel tableName = new JLabel("");

--- a/src/main/java/com/romraider/swing/RomCellRenderer.java
+++ b/src/main/java/com/romraider/swing/RomCellRenderer.java
@@ -31,7 +31,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTree;
-import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeCellRenderer;
 

--- a/src/main/java/com/romraider/swing/RomTree.java
+++ b/src/main/java/com/romraider/swing/RomTree.java
@@ -121,8 +121,9 @@ public class RomTree extends JTree implements MouseListener {
 	        		v = new Table3DView((Table3D)node.getTable());
 	        	else
 	        		return;
-	        	
-	        	 f = new TableFrame("Title", v);
+	        	 Rom rom = getRomNode(node);
+	        	 
+	        	 f = new TableFrame(node.getTable().getName() + " | " + rom.getFileName(), v);
         	}
             getEditor().displayTable(f);
         }

--- a/src/main/java/com/romraider/swing/RomTree.java
+++ b/src/main/java/com/romraider/swing/RomTree.java
@@ -35,13 +35,6 @@ import javax.swing.tree.TreePath;
 import com.romraider.editor.ecu.ECUEditor;
 import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.maps.Rom;
-import com.romraider.maps.Table1D;
-import com.romraider.maps.Table1DView;
-import com.romraider.maps.Table2D;
-import com.romraider.maps.Table2DView;
-import com.romraider.maps.Table3D;
-import com.romraider.maps.Table3DView;
-import com.romraider.maps.TableView;
 import com.romraider.util.SettingsManager;
 
 public class RomTree extends JTree implements MouseListener {
@@ -106,27 +99,7 @@ public class RomTree extends JTree implements MouseListener {
     }
 
     private void showTable(TableTreeNode selectedRow) {
-        TableTreeNode node = (TableTreeNode) selectedRow;
-        if (null != node) {
-        	TableFrame f = node.getFrame();
-        	
-        	if(f == null) {
-	        	TableView v;
-	        	
-	        	if(node.getTable() instanceof Table1D)
-	        		v = new Table1DView((Table1D)node.getTable());
-	        	else if(node.getTable() instanceof Table2D)
-	        		v = new Table2DView((Table2D)node.getTable());
-	        	else if(node.getTable() instanceof Table3D)
-	        		v = new Table3DView((Table3D)node.getTable());
-	        	else
-	        		return;
-	        	 Rom rom = getRomNode(node);
-	        	 
-	        	 f = new TableFrame(node.getTable().getName() + " | " + rom.getFileName(), v);
-        	}
-            getEditor().displayTable(f);
-        }
+        getEditor().displayTable(selectedRow);
     }
 
     private void setLastSelectedRom(Object selectedNode) {
@@ -142,7 +115,7 @@ public class RomTree extends JTree implements MouseListener {
         getEditor().refreshUI();
     }
 
-    private Rom getRomNode(Object currentNode){
+    public static Rom getRomNode(Object currentNode){
         if (currentNode == null) {
             return null;
         } else if(currentNode instanceof Rom) {

--- a/src/main/java/com/romraider/swing/RomTree.java
+++ b/src/main/java/com/romraider/swing/RomTree.java
@@ -35,6 +35,13 @@ import javax.swing.tree.TreePath;
 import com.romraider.editor.ecu.ECUEditor;
 import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.maps.Rom;
+import com.romraider.maps.Table1D;
+import com.romraider.maps.Table1DView;
+import com.romraider.maps.Table2D;
+import com.romraider.maps.Table2DView;
+import com.romraider.maps.Table3D;
+import com.romraider.maps.Table3DView;
+import com.romraider.maps.TableView;
 import com.romraider.util.SettingsManager;
 
 public class RomTree extends JTree implements MouseListener {
@@ -101,7 +108,23 @@ public class RomTree extends JTree implements MouseListener {
     private void showTable(TableTreeNode selectedRow) {
         TableTreeNode node = (TableTreeNode) selectedRow;
         if (null != node) {
-            getEditor().displayTable(node.getFrame());
+        	TableFrame f = node.getFrame();
+        	
+        	if(f == null) {
+	        	TableView v;
+	        	
+	        	if(node.getTable() instanceof Table1D)
+	        		v = new Table1DView((Table1D)node.getTable());
+	        	else if(node.getTable() instanceof Table2D)
+	        		v = new Table2DView((Table2D)node.getTable());
+	        	else if(node.getTable() instanceof Table3D)
+	        		v = new Table3DView((Table3D)node.getTable());
+	        	else
+	        		return;
+	        	
+	        	 f = new TableFrame("Title", v);
+        	}
+            getEditor().displayTable(f);
         }
     }
 

--- a/src/main/java/com/romraider/swing/SettingsForm.java
+++ b/src/main/java/com/romraider/swing/SettingsForm.java
@@ -1158,7 +1158,7 @@ public class SettingsForm extends JFrame implements MouseListener {
         for(JInternalFrame frame : getEditor().getRightPanel().getAllFrames()) {
             if(frame instanceof TableFrame && frame.isVisible()) {
                 TableFrame tableFrame = (TableFrame) frame;
-                tableFrame.getTable().drawTable();
+                tableFrame.getTable().getTableView().drawTable();
             }
         }
     }

--- a/src/main/java/com/romraider/swing/TableFrame.java
+++ b/src/main/java/com/romraider/swing/TableFrame.java
@@ -39,6 +39,8 @@ import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.logger.ecu.ui.handler.table.TableUpdateHandler;
 import com.romraider.maps.Rom;
 import com.romraider.maps.Table;
+import com.romraider.maps.TableView;
+import com.romraider.maps.UserLevelException;
 import com.romraider.util.ResourceUtil;
 
 public class TableFrame extends JInternalFrame implements InternalFrameListener, ActionListener {
@@ -46,10 +48,10 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
     private static final long serialVersionUID = -2651279694660392351L;
     private static final ResourceBundle rb = new ResourceUtil().getBundle(
             TableFrame.class.getName());
-    private final Table table;
+    private final TableView table;
     private TableMenuBar tableMenuBar = null;
 
-    public TableFrame(String title, Table table) {
+    public TableFrame(String title, TableView table) {
         super(title, true, true);
         this.table = table;
         add(table);
@@ -107,6 +109,9 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
     }
 
     public Table getTable() {
+        return table.getTable();
+    }
+    public TableView getTableView() {
         return table;
     }
 
@@ -121,54 +126,56 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
     @Override
     public void actionPerformed(ActionEvent e) {
         TableMenuBar menu = getTableMenuBar();
-
+        Table t = getTable();
+        
+        try {
         if (e.getSource() == menu.getUndoAll()) {
-            getTable().undoAll();
+            t.undoAll();
 
         } else if (e.getSource() == menu.getRevert()) {
-            getTable().setRevertPoint();
+            t.setRevertPoint();
 
         } else if (e.getSource() == menu.getUndoSel()) {
-            getTable().undoSelected();
+            getTableView().undoSelected();
 
         } else if (e.getSource() == menu.getClose()) {
             ECUEditorManager.getECUEditor().removeDisplayTable(this);
 
         } else if (e.getSource() == menu.getTableProperties()) {
-            JOptionPane.showMessageDialog(getTable(),
-                    new TablePropertyPanel(getTable()),
+            JOptionPane.showMessageDialog(getTableView(),
+                    new TablePropertyPanel(t),
                     MessageFormat.format(
                             rb.getString("TBLPROP"), getTable().getName()),
                     JOptionPane.INFORMATION_MESSAGE);
 
         } else if (e.getSource() == menu.getCopySel()) {
-            getTable().copySelection();
+            getTableView().copySelection();
 
         } else if (e.getSource() == menu.getCopyTable()) {
-            getTable().copyTable();
+            getTableView().copyTable();
 
         } else if (e.getSource() == menu.getPaste()) {
-            getTable().paste();
+            getTableView().paste();
 
         } else if (e.getSource() == menu.getCompareOff()) {
-            getTable().setCompareTable(null);
-            getTable().setCompareValueType(Settings.DataType.BIN);
+            t.setCompareTable(null);
+            t.setCompareValueType(Settings.DataType.BIN);
             getTableMenuBar().getCompareToBin().setSelected(true);
 
         } else if (e.getSource() == menu.getCompareAbsolute()) {
-            getTable().setCompareDisplay(Settings.CompareDisplay.ABSOLUTE);
+            getTableView().setCompareDisplay(Settings.CompareDisplay.ABSOLUTE);
 
         } else if (e.getSource() == menu.getComparePercent()) {
-            getTable().setCompareDisplay(Settings.CompareDisplay.PERCENT);
+            getTableView().setCompareDisplay(Settings.CompareDisplay.PERCENT);
 
         } else if (e.getSource() == menu.getCompareOriginal()) {
-            getTable().setCompareValueType(Settings.DataType.ORIGINAL);
+            t.setCompareValueType(Settings.DataType.ORIGINAL);
             getTableMenuBar().getCompareToOriginal().setSelected(true);
-            compareByTable(getTable());
+            compareByTable(t);
 
         } else if (e.getSource() == menu.getCompareMap()) {
             JTableChooser chooser = new JTableChooser();
-            Table selectedTable = chooser.showChooser(getTable());
+            Table selectedTable = chooser.showChooser(t);
             if(null != selectedTable) {
                 compareByTable(selectedTable);
             }
@@ -180,31 +187,38 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
             }
 
         } else if (e.getSource() == menu.getCompareToOriginal()) {
-            getTable().setCompareValueType(Settings.DataType.ORIGINAL);
-            getTable().refreshCompare();
+            t.setCompareValueType(Settings.DataType.ORIGINAL);
+            t.refreshCompare();
 
         } else if (e.getSource() == menu.getCompareToBin()) {
-            getTable().setCompareValueType(Settings.DataType.BIN);
-            getTable().refreshCompare();
+            t.setCompareValueType(Settings.DataType.BIN);
+            t.refreshCompare();
 
         } else if (e.getSource() == menu.getInterp()) {
-            getTable().interpolate();
+            getTableView().interpolate();
 
         } else if (e.getSource() == menu.getVertInterp()) {
-            getTable().verticalInterpolate();
+            getTableView().verticalInterpolate();
 
         } else if (e.getSource() == menu.getHorizInterp()) {
-            getTable().horizontalInterpolate();
+            getTableView().horizontalInterpolate();
+        }
+        }
+        catch(UserLevelException ex) {
+        	TableView.showInvalidUserLevelPopup(ex);
         }
     }
 
     public void compareByTable(Table selectedTable) {
+    	Table t = getTable();
+    	
         if(null == selectedTable) {
             return;
         }
-        getTable().setCompareTable(selectedTable);
-        ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(getTable());
-        getTable().populateCompareValues(selectedTable);
+        
+        t.setCompareTable(selectedTable);
+        ECUEditorManager.getECUEditor().getTableToolBar().updateTableToolBar(t);
+        t.populateCompareValues(selectedTable);
     }
 
     public void refreshSimilarOpenTables() {

--- a/src/main/java/com/romraider/swing/TableFrame.java
+++ b/src/main/java/com/romraider/swing/TableFrame.java
@@ -70,7 +70,7 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         addInternalFrameListener(this);
     }
-
+    
     @Override
     public void internalFrameActivated(InternalFrameEvent e) {
         ECUEditor parent = getEditor();

--- a/src/main/java/com/romraider/swing/TableFrame.java
+++ b/src/main/java/com/romraider/swing/TableFrame.java
@@ -204,13 +204,13 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
             t.refreshCompare();
 
         } else if (e.getSource() == menu.getInterp()) {
-            getTableView().interpolate();
+            getTable().interpolate();
 
         } else if (e.getSource() == menu.getVertInterp()) {
-            getTableView().verticalInterpolate();
+        	getTable().verticalInterpolate();
 
         } else if (e.getSource() == menu.getHorizInterp()) {
-            getTableView().horizontalInterpolate();
+        	getTable().horizontalInterpolate();
         }
         }
         catch(UserLevelException ex) {

--- a/src/main/java/com/romraider/swing/TableFrame.java
+++ b/src/main/java/com/romraider/swing/TableFrame.java
@@ -48,13 +48,18 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
     private static final long serialVersionUID = -2651279694660392351L;
     private static final ResourceBundle rb = new ResourceUtil().getBundle(
             TableFrame.class.getName());
-    private final TableView table;
+    private final TableView tableView;
     private TableMenuBar tableMenuBar = null;
 
-    public TableFrame(String title, TableView table) {
+    public TableFrame(String title, TableView tableView) {
         super(title, true, true);
-        this.table = table;
-        add(table);
+        this.tableView = tableView;
+        Table t = tableView.getTable();
+        t.setTableFrame(this);
+        
+        add(tableView);
+        tableView.repaint();
+        
         setFrameIcon(null);
         setBorder(createBevelBorder(0));
         if (System.getProperty("os.name").startsWith("Mac OS"))
@@ -109,10 +114,10 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
     }
 
     public Table getTable() {
-        return table.getTable();
+        return tableView.getTable();
     }
     public TableView getTableView() {
-        return table;
+        return tableView;
     }
 
     public ECUEditor getEditor() {
@@ -229,7 +234,7 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
             for(TableTreeNode tableNode : rom.getTableNodes()) {
                 if(tableNode.getTable().getName().equalsIgnoreCase(getTable().getName())) {
                     JRadioButtonMenuItem similarTable = new TableMenuItem(rom.getFileName());
-                    similarTable.setToolTipText(tableNode.getFrame().getTable().getName());
+                    similarTable.setToolTipText(tableNode.getTable().getName());
                     similarTable.addActionListener(this);
                     similarTables.add(similarTable);
                     break;

--- a/src/main/java/com/romraider/swing/TableFrame.java
+++ b/src/main/java/com/romraider/swing/TableFrame.java
@@ -48,7 +48,7 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
     private static final long serialVersionUID = -2651279694660392351L;
     private static final ResourceBundle rb = new ResourceUtil().getBundle(
             TableFrame.class.getName());
-    private final TableView tableView;
+    private TableView tableView;
     private TableMenuBar tableMenuBar = null;
 
     public TableFrame(String title, TableView tableView) {
@@ -120,6 +120,10 @@ public class TableFrame extends JInternalFrame implements InternalFrameListener,
         return tableView;
     }
 
+    public void setTableView(TableView v) {
+    	tableView = v;
+    }
+    
     public ECUEditor getEditor() {
         return ECUEditorManager.getECUEditor();
     }

--- a/src/main/java/com/romraider/swing/TableMenuBar.java
+++ b/src/main/java/com/romraider/swing/TableMenuBar.java
@@ -31,6 +31,7 @@ import javax.swing.JSeparator;
 
 import com.romraider.maps.Table;
 import com.romraider.maps.Table3D;
+import com.romraider.maps.Table3DView;
 import com.romraider.util.ResourceUtil;
 
 public class TableMenuBar extends JMenuBar {

--- a/src/main/java/com/romraider/swing/TablePropertyPanel.java
+++ b/src/main/java/com/romraider/swing/TablePropertyPanel.java
@@ -345,7 +345,7 @@ public class TablePropertyPanel extends javax.swing.JPanel {
         final String[] paramEntries = logParams.split(", ");
         for (String entry : paramEntries) {
             final String[] entries = entry.split(":");
-            if(!paramMap.containsKey(entries[0])){
+            if(entries.length > 0 && !paramMap.containsKey(entries[0])){
                 paramMap.put(entries[0], entries.length > 1 ? entries[1] : "n/a");
             }
         }

--- a/src/main/java/com/romraider/swing/TablePropertyPanel.java
+++ b/src/main/java/com/romraider/swing/TablePropertyPanel.java
@@ -53,10 +53,6 @@ public class TablePropertyPanel extends javax.swing.JPanel {
     if (Table.TableType.SWITCH == table.getType()) {
         dim = 1;
         storageSize.setText("switch");
-        if(table.getClass() == TableSwitch.class) {
-            scrollPane.setViewportView(populateScalesTable(
-                    ((TableSwitch) table).getSwitchStates()));
-        }
     }
     else {
         if (Settings.STORAGE_TYPE_FLOAT == table.getStorageType()) {

--- a/src/main/java/com/romraider/swing/TableToolBar.java
+++ b/src/main/java/com/romraider/swing/TableToolBar.java
@@ -65,11 +65,14 @@ import com.ecm.graphics.data.GraphData;
 import com.ecm.graphics.data.GraphDataListener;
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
+import com.romraider.maps.DataCell;
 import com.romraider.maps.DataCellView;
 import com.romraider.maps.Scale;
 import com.romraider.maps.Table;
 import com.romraider.maps.Table1D;
 import com.romraider.maps.Table3D;
+import com.romraider.maps.TableView;
+import com.romraider.maps.UserLevelException;
 import com.romraider.util.NumberUtil;
 import com.romraider.util.ResourceUtil;
 import com.romraider.util.SettingsManager;
@@ -231,7 +234,12 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
                 } catch (PropertyVetoException ex) {
                 }
                 frame.requestFocusInWindow();
-                setValue(frame.getTable());
+                
+                try {
+					setValue(frame.getTable());
+				} catch (UserLevelException e1) {
+					e1.printStackTrace();
+				}
             }
         };
 
@@ -367,7 +375,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
 
         updateToolbarIncrementDecrementValues();
 
-        this.overlayLog.setSelected(selectedTable.getOverlayLog());
+        this.overlayLog.setSelected(selectedTable.getTableView().getOverlayLog());
         this.enable3d.setEnabled(selectedTable.getType() == Table.TableType.TABLE_3D);
 
         setScales(selectedTable.getScales());
@@ -515,33 +523,37 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         {
             return;
         }
-
-        if (e.getSource() == incrementCoarse) {
-            incrementCoarse(curTable);
-        } else if (e.getSource() == decrementCoarse) {
-            decrementCoarse(curTable);
-        } else if (e.getSource() == enable3d) {
-            enable3d(curTable);
-        } else if (e.getSource() == incrementFine) {
-            incrementFine(curTable);
-        } else if (e.getSource() == decrementFine) {
-            decrementFine(curTable);
-        } else if (e.getSource() == multiply) {
-            multiply(curTable);
-        } else if (e.getSource() == setValue) {
-            setValue(curTable);
-        } else if (e.getSource() == colorCells) {
-            colorCells(curTable);
-        } else if (e.getSource() == refreshCompare) {
-            refreshCompare(curTable);
+        try {
+	        if (e.getSource() == incrementCoarse) {
+	            incrementCoarse(curTable);
+	        } else if (e.getSource() == decrementCoarse) {
+	            decrementCoarse(curTable);
+	        } else if (e.getSource() == enable3d) {
+	            enable3d(curTable);
+	        } else if (e.getSource() == incrementFine) {
+	            incrementFine(curTable);
+	        } else if (e.getSource() == decrementFine) {
+	            decrementFine(curTable);
+	        } else if (e.getSource() == multiply) {
+	            multiply(curTable);
+	        } else if (e.getSource() == setValue) {
+	            setValue(curTable);
+	        } else if (e.getSource() == colorCells) {
+	            colorCells(curTable);
+	        } else if (e.getSource() == refreshCompare) {
+	            refreshCompare(curTable);
+	        }
+        }
+        catch(UserLevelException ex) {
+        	TableView.showInvalidUserLevelPopup(ex);
         }
     }
 
-    public void setValue(Table currentTable) {
-        currentTable.setRealValue(setValueText.getText());
+    public void setValue(Table currentTable) throws UserLevelException {
+        currentTable.getTableView().setRealValue(setValueText.getText());
     }
 
-    public void multiply() {
+    public void multiply() throws UserLevelException {
         Table curTable = getSelectedTable();
         if(null == curTable) {
             return;
@@ -549,15 +561,15 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         multiply(curTable);
     }
 
-    public void multiply(Table currentTable) {
+    public void multiply(Table currentTable) throws UserLevelException {
         try{
-            currentTable.multiply(NumberUtil.doubleValue(setValueText.getText()));
+            currentTable.getTableView().multiply(NumberUtil.doubleValue(setValueText.getText()));
         }catch(ParseException nex) {
             LOGGER.error(this.getClass().getName() + ".multiply(" + currentTable + ") " + nex);
         }
     }
 
-    public void incrementFine() {
+    public void incrementFine() throws NumberFormatException, UserLevelException {
         Table curTable = getSelectedTable();
         if(null == curTable) {
             return;
@@ -565,11 +577,11 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         incrementFine(curTable);
     }
 
-    public void incrementFine(Table currentTable) {
-        currentTable.increment(Double.parseDouble(String.valueOf(incrementByFine.getValue())));
+    public void incrementFine(Table currentTable) throws NumberFormatException, UserLevelException {
+        currentTable.getTableView().increment(Double.parseDouble(String.valueOf(incrementByFine.getValue())));
     }
 
-    public void decrementFine() {
+    public void decrementFine() throws NumberFormatException, UserLevelException {
         Table curTable = getSelectedTable();
         if(null == curTable) {
             return;
@@ -577,11 +589,11 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         decrementFine(curTable);
     }
 
-    public void decrementFine(Table currentTable) {
-        currentTable.increment(0 - Double.parseDouble(String.valueOf(incrementByFine.getValue())));
+    public void decrementFine(Table currentTable) throws NumberFormatException, UserLevelException {
+        currentTable.getTableView().increment(0 - Double.parseDouble(String.valueOf(incrementByFine.getValue())));
     }
 
-    public void incrementCoarse() {
+    public void incrementCoarse() throws NumberFormatException, UserLevelException {
         Table curTable = getSelectedTable();
         if(null == curTable) {
             return;
@@ -589,11 +601,11 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         incrementCoarse(curTable);
     }
 
-    public void incrementCoarse(Table currentTable) {
-        currentTable.increment(Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
+    public void incrementCoarse(Table currentTable) throws NumberFormatException, UserLevelException {
+        currentTable.getTableView().increment(Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
     }
 
-    public void decrementCoarse() {
+    public void decrementCoarse() throws NumberFormatException, UserLevelException {
         Table curTable = getSelectedTable();
         if(null == curTable) {
             return;
@@ -601,8 +613,8 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         decrementCoarse(curTable);
     }
 
-    public void decrementCoarse(Table currentTable) {
-        currentTable.increment(0 - Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
+    public void decrementCoarse(Table currentTable) throws NumberFormatException, UserLevelException {
+        currentTable.getTableView().increment(0 - Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
     }
 
     /**
@@ -618,16 +630,16 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
 
         if (currentTable.getType() == Table.TableType.TABLE_3D) {
             Table3D table3d = (Table3D) currentTable;
-            DataCellView[][] tableData = table3d.get3dData();
+            DataCell[][] tableData = table3d.get3dData();
             valueCount = tableData.length;
-            DataCellView[] dataRow = tableData[0];
+            DataCell[] dataRow = tableData[0];
             rowCount = dataRow.length;
 
             for (int j = (rowCount - 1); j >= 0; j--) {
                 float[] rowValues = new float[valueCount];
                 for (int i = 0; i < valueCount; i++) {
-                    DataCellView theCell = tableData[i][j];
-                    rowValues[i] = (float) theCell.getDataCell().getRealValue();
+                    DataCell theCell = tableData[i][j];
+                    rowValues[i] = (float) theCell.getRealValue();
                 }
                 graphValues.add(rowValues);
             }
@@ -636,12 +648,12 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
             Table1D yAxisTable1D = table3d.getYAxis();
 
             //Gather x axis values
-            DataCellView[] dataCells = xAxisTable1D.getData();
+            DataCell[] dataCells = xAxisTable1D.getData();
             int length = dataCells.length;
             double[] xValues = new double[length];
 
             for (int i = 0; i < length; i++) {
-                xValues[i] = dataCells[i].getDataCell().getRealValue();
+                xValues[i] = dataCells[i].getRealValue();
             }
 
             //Gather y/z axis values
@@ -650,7 +662,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
             double[] yValues = new double[length];
 
             for (int i = 0; i < length; i++) {
-                double theValue = dataCells[i].getDataCell().getRealValue();
+                double theValue = dataCells[i].getRealValue();
                 BigDecimal finalRoundedValue = new BigDecimal(theValue).setScale(2, BigDecimal.ROUND_HALF_UP);
                 yValues[i] = finalRoundedValue.doubleValue();
             }
@@ -763,7 +775,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
             }
         } else if (e.getSource() == overlayLog) {
             // enable/disable log overlay and live data display
-            curTable.setOverlayLog(overlayLog.isSelected());
+            curTable.getTableView().setOverlayLog(overlayLog.isSelected());
         }
     }
 
@@ -777,7 +789,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
 
         if (e.getSource() == clearOverlay) {
             // clear log overlay
-            curTable.clearLiveDataTrace();
+            curTable.getTableView().clearLiveDataTrace();
         }
     }
 
@@ -799,10 +811,14 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
 
         if(curTable.getType() == Table.TableType.TABLE_3D) {
             Table3D table3d = (Table3D) curTable;
-            table3d.selectCellAt(x, table3d.getSizeY() - z - 1);
+            table3d.getTableView().selectCellAt(x, table3d.getSizeY() - z - 1);
 
             //Set the value
-            table3d.setRealValue(String.valueOf(value));
+            try {
+				table3d.getTableView().setRealValue(String.valueOf(value));
+			} catch (UserLevelException e) {
+				e.printStackTrace();
+			}
         }
     }
 
@@ -816,10 +832,10 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         if(curTable.getType() == Table.TableType.TABLE_3D) {
             if (value) {
                 Table3D table3d = (Table3D) curTable;
-                table3d.selectCellAtWithoutClear(x, table3d.getSizeY() - z - 1);
+                table3d.getTableView().selectCellAtWithoutClear(x, table3d.getSizeY() - z - 1);
             } else {
                 Table3D table3d = (Table3D) curTable;
-                table3d.deSelectCellAt(x, table3d.getSizeY() - z - 1);
+                table3d.getTableView().deSelectCellAt(x, table3d.getSizeY() - z - 1);
             }
         }
     }

--- a/src/main/java/com/romraider/swing/TableToolBar.java
+++ b/src/main/java/com/romraider/swing/TableToolBar.java
@@ -66,7 +66,6 @@ import com.ecm.graphics.data.GraphDataListener;
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.maps.DataCell;
-import com.romraider.maps.DataCellView;
 import com.romraider.maps.Scale;
 import com.romraider.maps.Table;
 import com.romraider.maps.Table1D;
@@ -98,7 +97,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     private final ECUEditorNumberField incrementByCoarse = new ECUEditorNumberField();
     private final ECUEditorNumberField setValueText = new ECUEditorNumberField();
 
-    private final JComboBox scaleSelection = new JComboBox();
+    private final JComboBox<String> scaleSelection = new JComboBox<String>();
 
     private final JPanel liveDataPanel = new JPanel();
     private final JCheckBox overlayLog = new JCheckBox(rb.getString("OVERLAYLOG"));
@@ -553,7 +552,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     }
 
     public void setValue(Table currentTable) throws UserLevelException {
-        currentTable.getTableView().setRealValue(setValueText.getText());
+        currentTable.setRealValue(setValueText.getText());
     }
 
     public void multiply() throws UserLevelException {
@@ -566,7 +565,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
 
     public void multiply(Table currentTable) throws UserLevelException {
         try{
-            currentTable.getTableView().multiply(NumberUtil.doubleValue(setValueText.getText()));
+            currentTable.multiply(NumberUtil.doubleValue(setValueText.getText()));
         }catch(ParseException nex) {
             LOGGER.error(this.getClass().getName() + ".multiply(" + currentTable + ") " + nex);
         }
@@ -581,7 +580,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     }
 
     public void incrementFine(Table currentTable) throws NumberFormatException, UserLevelException {
-        currentTable.getTableView().increment(Double.parseDouble(String.valueOf(incrementByFine.getValue())));
+        currentTable.increment(Double.parseDouble(String.valueOf(incrementByFine.getValue())));
     }
 
     public void decrementFine() throws NumberFormatException, UserLevelException {
@@ -593,7 +592,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     }
 
     public void decrementFine(Table currentTable) throws NumberFormatException, UserLevelException {
-        currentTable.getTableView().increment(0 - Double.parseDouble(String.valueOf(incrementByFine.getValue())));
+        currentTable.increment(0 - Double.parseDouble(String.valueOf(incrementByFine.getValue())));
     }
 
     public void incrementCoarse() throws NumberFormatException, UserLevelException {
@@ -605,7 +604,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     }
 
     public void incrementCoarse(Table currentTable) throws NumberFormatException, UserLevelException {
-        currentTable.getTableView().increment(Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
+        currentTable.increment(Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
     }
 
     public void decrementCoarse() throws NumberFormatException, UserLevelException {
@@ -617,7 +616,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     }
 
     public void decrementCoarse(Table currentTable) throws NumberFormatException, UserLevelException {
-        currentTable.getTableView().increment(0 - Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
+        currentTable.increment(0 - Double.parseDouble(String.valueOf(incrementByCoarse.getValue())));
     }
 
     /**
@@ -770,7 +769,6 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         if (e.getSource() == scaleSelection) {
             // scale changed
             try {
-
                 curTable.setScaleByName((String)scaleSelection.getSelectedItem());
                 updateToolbarIncrementDecrementValues();
             } catch (NameNotFoundException e1) {
@@ -814,11 +812,11 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
 
         if(curTable.getType() == Table.TableType.TABLE_3D) {
             Table3D table3d = (Table3D) curTable;
-            table3d.getTableView().selectCellAt(x, table3d.getSizeY() - z - 1);
+            table3d.selectCellAt(x, table3d.getSizeY() - z - 1);
 
             //Set the value
             try {
-				table3d.getTableView().setRealValue(String.valueOf(value));
+				table3d.setRealValue(String.valueOf(value));
 			} catch (UserLevelException e) {
 				e.printStackTrace();
 			}
@@ -835,10 +833,10 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
         if(curTable.getType() == Table.TableType.TABLE_3D) {
             if (value) {
                 Table3D table3d = (Table3D) curTable;
-                table3d.getTableView().selectCellAtWithoutClear(x, table3d.getSizeY() - z - 1);
+                table3d.selectCellAtWithoutClear(x, table3d.getSizeY() - z - 1);
             } else {
                 Table3D table3d = (Table3D) curTable;
-                table3d.getTableView().deSelectCellAt(x, table3d.getSizeY() - z - 1);
+                table3d.deSelectCellAt(x, table3d.getSizeY() - z - 1);
             }
         }
     }

--- a/src/main/java/com/romraider/swing/TableToolBar.java
+++ b/src/main/java/com/romraider/swing/TableToolBar.java
@@ -97,7 +97,7 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     private final ECUEditorNumberField incrementByCoarse = new ECUEditorNumberField();
     private final ECUEditorNumberField setValueText = new ECUEditorNumberField();
 
-    private final JComboBox<String> scaleSelection = new JComboBox<String>();
+    private final JComboBox scaleSelection = new JComboBox();
 
     private final JPanel liveDataPanel = new JPanel();
     private final JCheckBox overlayLog = new JCheckBox(rb.getString("OVERLAYLOG"));
@@ -312,7 +312,10 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     }
 
     public void updateTableToolBar() {
-        this.updateTableToolBar(getTable());
+    	Table t = getTable();
+    	
+    	if(t != null)
+    		this.updateTableToolBar(getTable());
     }
 
     

--- a/src/main/java/com/romraider/swing/TableToolBar.java
+++ b/src/main/java/com/romraider/swing/TableToolBar.java
@@ -348,6 +348,9 @@ public class TableToolBar extends JToolBar implements MouseListener, ItemListene
     }
     	
     public void updateTableToolBar(Table selectedTable) {
+    	//Select the parent Table always instead?
+    	//if(selectedTable instanceof Table1D)selectedTable = ((Table1D)selectedTable).getAxisParent();
+    	
         if(selectedTable == null  && this.selectedTable == null) {
             // Skip if the table is the same to avoid multiple updates
             return;

--- a/src/main/java/com/romraider/swing/TableTreeNode.java
+++ b/src/main/java/com/romraider/swing/TableTreeNode.java
@@ -35,7 +35,7 @@ public class TableTreeNode extends DefaultMutableTreeNode {
     }
 
     public TableFrame getFrame() {
-    	return table.getTableView().getFrame();  	
+    	return table.getTableFrame(); 	
     }
     
     public void setTable(Table t) {

--- a/src/main/java/com/romraider/swing/TableTreeNode.java
+++ b/src/main/java/com/romraider/swing/TableTreeNode.java
@@ -25,26 +25,25 @@ import com.romraider.maps.Table;
 
 public class TableTreeNode extends DefaultMutableTreeNode {
 
+	Table table;
     private static final long serialVersionUID = 2824050968863990871L;
     private String toolTip;
 
-    public TableTreeNode(TableFrame tableFrame) {
-        super(tableFrame);
+    public TableTreeNode(Table t) {
+        super(t);
+    	this.table = t;
     }
 
     public TableFrame getFrame() {
-        if(getUserObject() instanceof TableFrame) {
-            return (TableFrame)getUserObject();
-        }
-        return null;
+    	return table.getTableView().getFrame();  	
     }
-
-    public void setFrame(TableFrame tableFrame) {
-        this.setUserObject(tableFrame);
+    
+    public void setTable(Table t) {
+        this.setUserObject(t);
     }
 
     public Table getTable() {
-        return this.getFrame().getTable();
+        return table;
     }
 
     public void setToolTipText(String input) {

--- a/src/main/java/com/romraider/util/JEPUtil.java
+++ b/src/main/java/com/romraider/util/JEPUtil.java
@@ -44,9 +44,6 @@ public final class JEPUtil {
     private static final Map<String, JEP> parserCache =
     		Collections.synchronizedMap(new LRUCache<String, JEP>(32));
 
-    private JEPUtil() {
-    }
-
     public static synchronized double evaluate(String expression, double value) {
         JEP parser = parserCache.get(expression);
         if (parser == null) {

--- a/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMRomUnmarshaller.java
@@ -62,7 +62,7 @@ public final class DOMRomUnmarshaller {
         	Rom rom = new Rom(romId);
 	        Rom output = unmarshallRom(n, rom);
 	        
-	        // set ram offset
+	        //Set ram offset
 	        output.getRomID().setRamOffset(
 	                output.getRomID().getFileSize()
 	                - input.length);

--- a/src/main/java/com/romraider/xml/RomAttributeParser.java
+++ b/src/main/java/com/romraider/xml/RomAttributeParser.java
@@ -232,20 +232,17 @@ public final class RomAttributeParser {
 	}
 
     public static int parseFileSize(String input) throws NumberFormatException {
-        try {
-            return Integer.parseInt(input);
-        } catch (NumberFormatException ex) {
-            if (input.substring(input.length() - 2).equalsIgnoreCase("kb")) {
-                return Integer.parseInt(input.substring(0, input.length() - 2)) * 1024;
-            }
-            else if (input.substring(input.length() - 2).equalsIgnoreCase("mb")) {
-                return Integer.parseInt(input.substring(0, input.length() - 2)) * 1024 * 1024;
-            }
-            else if (input.substring(input.length() - 1).equalsIgnoreCase("b")) {
-                return Integer.parseInt(input.substring(0, input.length() - 1));
-            }
-            throw new NumberFormatException();
+        if (input.substring(input.length() - 2).equalsIgnoreCase("kb")) {
+            return Integer.parseInt(input.substring(0, input.length() - 2)) * 1024;
         }
+        else if (input.substring(input.length() - 2).equalsIgnoreCase("mb")) {
+            return Integer.parseInt(input.substring(0, input.length() - 2)) * 1024 * 1024;
+        }
+        else if (input.substring(input.length() - 1).equalsIgnoreCase("b")) {
+            return Integer.parseInt(input.substring(0, input.length() - 1));
+        }
+        
+        return Integer.parseInt(input);
     }
 
     public static byte[] floatToByte(float input, Settings.Endian endian, Settings.Endian memModelEndian) {

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -288,7 +288,7 @@ public class TableScaleUnmarshaller {
 
 	                } else if (n.getNodeName().equalsIgnoreCase("data")) {
 	                    // parse and add data to table
-	                    DataCell c = new DataCell(table, unmarshallText(n));
+	                    DataCell c = new DataCell(table, unmarshallText(n), null);
 	                    if(table instanceof Table1D) {
 	                        ((Table1D)table).addStaticDataCell(c);
 	                    } else {

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -37,7 +37,6 @@ import org.w3c.dom.NodeList;
 
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
-import com.romraider.maps.DataCell;
 import com.romraider.maps.Rom;
 import com.romraider.maps.Scale;
 import com.romraider.maps.Table;
@@ -286,9 +285,8 @@ public class TableScaleUnmarshaller {
 
 	                } else if (n.getNodeName().equalsIgnoreCase("data")) {
 	                    // parse and add data to table
-	                    DataCell c = new DataCell(table, unmarshallText(n), null);
-	                    if(table instanceof Table1D) {
-	                        ((Table1D)table).addStaticDataCell(c);
+	                    if(table instanceof Table1D) {		                    
+	                        ((Table1D)table).addStaticDataCell(unmarshallText(n));
 	                    } else {
 	                        // Why would this happen.  Static should only be for axis.
 	                        LOGGER.error("Error adding static data cell.");

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -238,8 +238,9 @@ public class TableScaleUnmarshaller {
 	                            if (tempTable.getDataSize() != table.getDataSize()) {
 	                                tempTable.setDataSize(table.getDataSize());
 	                            }
-	                            ((Table2D) table).setAxis(tempTable);
 	                            tempTable.setData(((Table2D) table).getAxis().getData());
+	                            ((Table2D) table).setAxis(tempTable);
+	                            
 
 	                        }
 	                    } else if (table.getType() == Table.TableType.TABLE_3D) { // if table
@@ -257,9 +258,9 @@ public class TableScaleUnmarshaller {
 	                                tempTable.setDataSize(((Table3D) table)
 	                                        .getSizeX());
 	                            }
-	                            
-	                            ((Table3D) table).setXAxis(tempTable);
 	                            tempTable.setData(((Table3D) table).getXAxis().getData());
+	                            ((Table3D) table).setXAxis(tempTable);
+	                            
 
 	                        } else if (RomAttributeParser
 	                                .parseTableType(unmarshallAttribute(n, "type",
@@ -272,11 +273,8 @@ public class TableScaleUnmarshaller {
 	                                tempTable.setDataSize(((Table3D) table)
 	                                        .getSizeY());
 	                            }
+	                            tempTable.setData(((Table3D) table).getYAxis().getData());
 	                            ((Table3D) table).setYAxis(tempTable);
-	                            tempTable.setData(((Table3D) table).getYAxis()
-	                                    .getData());
-
-
 	                        }
 	                    }
 

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -38,7 +38,6 @@ import org.w3c.dom.NodeList;
 import com.romraider.Settings;
 import com.romraider.editor.ecu.ECUEditorManager;
 import com.romraider.maps.DataCell;
-import com.romraider.maps.DataCellView;
 import com.romraider.maps.Rom;
 import com.romraider.maps.Scale;
 import com.romraider.maps.Table;
@@ -112,14 +111,9 @@ public class TableScaleUnmarshaller {
 	            if (tableNames.containsKey(tn) || type.contains("xis")) {
 	                if (type.equalsIgnoreCase("3D")) {
 	                    table = new Table3D();
-	                    table.getScales().add(rawScale);
-	                    ((Table3D) table).getXAxis().getScales().add(rawScale);
-	                    ((Table3D) table).getYAxis().getScales().add(rawScale);
 
 	                } else if (type.equalsIgnoreCase("2D")) {
 	                    table = new Table2D();
-	                    table.getScales().add(rawScale);
-	                    ((Table2D) table).getAxis().getScales().add(rawScale);
 
 	                } else if (type.equalsIgnoreCase("1D")) {
 	                    table = new Table1D(Table.TableType.TABLE_1D);
@@ -144,7 +138,8 @@ public class TableScaleUnmarshaller {
 	                else {
 	                    throw new XMLParseException("Table type " + type + " unknown for "
 	                            + tableNode.getAttributes().getNamedItem("name"));
-	                }
+	                }	                
+                    table.getScales().add(rawScale);
 	            }
 	            else {
 	                return table;
@@ -243,9 +238,8 @@ public class TableScaleUnmarshaller {
 	                            if (tempTable.getDataSize() != table.getDataSize()) {
 	                                tempTable.setDataSize(table.getDataSize());
 	                            }
-	                            tempTable.setData(((Table2D) table).getAxis()
-	                                    .getData());
 	                            ((Table2D) table).setAxis(tempTable);
+	                            tempTable.setData(((Table2D) table).getAxis().getData());
 
 	                        }
 	                    } else if (table.getType() == Table.TableType.TABLE_3D) { // if table
@@ -263,9 +257,9 @@ public class TableScaleUnmarshaller {
 	                                tempTable.setDataSize(((Table3D) table)
 	                                        .getSizeX());
 	                            }
-	                            tempTable.setData(((Table3D) table).getXAxis()
-	                                    .getData());
+	                            
 	                            ((Table3D) table).setXAxis(tempTable);
+	                            tempTable.setData(((Table3D) table).getXAxis().getData());
 
 	                        } else if (RomAttributeParser
 	                                .parseTableType(unmarshallAttribute(n, "type",
@@ -278,9 +272,10 @@ public class TableScaleUnmarshaller {
 	                                tempTable.setDataSize(((Table3D) table)
 	                                        .getSizeY());
 	                            }
+	                            ((Table3D) table).setYAxis(tempTable);
 	                            tempTable.setData(((Table3D) table).getYAxis()
 	                                    .getData());
-	                            ((Table3D) table).setYAxis(tempTable);
+
 
 	                        }
 	                    }

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -294,9 +294,8 @@ public class TableScaleUnmarshaller {
 	                } else if (n.getNodeName().equalsIgnoreCase("data")) {
 	                    // parse and add data to table
 	                    DataCell c = new DataCell(table, unmarshallText(n));
-	                    DataCellView dataCell = new DataCellView(c);
 	                    if(table instanceof Table1D) {
-	                        ((Table1D)table).addStaticDataCell(dataCell);
+	                        ((Table1D)table).addStaticDataCell(c);
 	                    } else {
 	                        // Why would this happen.  Static should only be for axis.
 	                        LOGGER.error("Error adding static data cell.");


### PR DESCRIPTION
Hi,
this was quite a giant job, but I managed to split the Editor tables into data and GUI tables. I needed a couple of days just to make it compile again... The data tables are created when the binary is parsed, while the GUI/Swing tables are only created once you click on them. The TableSwitch is just a Table1D now with presets and hidden data, so it will look a bit different but keep its functionality. The Subaru checksum stuff is also still in there. I have tested different BMW and Subaru bins, including copying/pasting, interpolation and comparing. Only thing I couldnt test yet is the overlay function, but I would rather merge this now than having a giant merge conflict later.

As a benefit you should notice that loading binaries is way faster now, its basically instant. As an additional benefit for the future it should be possible to test binary parsing without any gui and just Table classes.

Another small change includes keeping the current file extension on saving.

I also played around with the FlatLeaf theme, which is a free lookAndFeel for Swing. With minimal work RomRaider could be switched to a dark theme I think, for that more 2021 look. But thats not included in this commit.