### PR TITLE
Important: Restore Directory Filter for Binary Definition

### DIFF
--- a/src/main/java/com/romraider/swing/DefinitionFilter.java
+++ b/src/main/java/com/romraider/swing/DefinitionFilter.java
@@ -49,7 +49,7 @@ public class DefinitionFilter extends FileFilter {
     public boolean accept(File f) {
         if (f != null) {
             if (f.isDirectory()) {
-                return false;
+                return true;
             }
             for (String s : regexFilters) {
             	if(f.getName().matches(s)) return true;


### PR DESCRIPTION
Hi,
I accidentally disabled the directory filter in a previous pull request. So you cannot switch directories in the file picker for the editor definitions. Sorry about that!