### PR TITLE
Bitwise Table Refactoring

### DIFF
--- a/src/main/java/com/romraider/editor/ecu/OpenImageWorker.java
+++ b/src/main/java/com/romraider/editor/ecu/OpenImageWorker.java
@@ -171,12 +171,14 @@ public class OpenImageWorker extends SwingWorker<Void, Void> {
 	    	    loadRom(rom, input);	
 
         } catch (StackOverflowError ex) {
+        	ex.printStackTrace();
             // handles looped inheritance, which will use up all available memory
             showMessageDialog(editor,
                     ECUEditor.rb.getString("LOOPEDBASE"),
                     errorLoading,
                     ERROR_MESSAGE);
         } catch (OutOfMemoryError ome) {
+        	ome.printStackTrace();
             // handles Java heap space issues when loading multiple Roms.
             showMessageDialog(editor,
                     ECUEditor.rb.getString("OUTOFMEMORY"),

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -524,11 +524,12 @@ public class DataCell implements Serializable  {
                 this.setBinValue(roundResult);
             }
         }
-
+        
+        //Make sure we always change something. If the defined increment is too small this triggers
+        //TODO: This should use real values
         if (table.getStorageType() != Settings.STORAGE_TYPE_FLOAT &&
                 oldValue == getRealValue() &&
-                binValue > 0.0 &&
-                binValue < maxAllowedBin) {
+                ((increment > 0 && binValue < maxAllowedBin) || (increment < 0 && binValue > minAllowedBin))) {
             if (LOGGER.isDebugEnabled())
                 LOGGER.debug(maxAllowedBin + " " + binValue);
             increment(increment * 2);

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -64,7 +64,6 @@ public class DataCell implements Serializable  {
         this.table = table;
         this.rom = rom;
         setBitMask(table.getBitMask()); //Take the global bitmask first
-        calcValueRange();
     }
 
     public DataCell(Table table, String staticText, Rom rom) {
@@ -130,14 +129,12 @@ public class DataCell implements Serializable  {
                 }
             }
             else {
-
                 if(bitMask == 0) {
                     maxAllowedBin = (Math.pow(256, table.getStorageType()) - 1);
                 }
                 else {
                     maxAllowedBin =(int)(Math.pow(2,ByteUtil.lengthOfMask(bitMask)) - 1);
                 }
-
                 minAllowedBin = 0.0;
             }
         } else {

--- a/src/main/java/com/romraider/maps/DataCell.java
+++ b/src/main/java/com/romraider/maps/DataCell.java
@@ -367,6 +367,7 @@ public class DataCell implements Serializable  {
     public boolean isSelected() {
         return isSelected;
     }
+    
     public void updateBinValueFromMemory() {
         this.binValue = getValueFromMemory();
         updateView();
@@ -548,6 +549,10 @@ public class DataCell implements Serializable  {
     public void setOriginalValue(double originalValue) {
         this.originalValue = originalValue;
     }
+    
+    public int getBitMask() {
+    	return this.bitMask;
+    }
 
     public void setCompareValue(DataCell compareCell) {
         if(Settings.DataType.BIN == table.getCompareValueType())
@@ -567,17 +572,13 @@ public class DataCell implements Serializable  {
     }
 
     public void multiply(double factor) throws UserLevelException {
-        if(table.getCurrentScale().getCategory().equals("Raw Value"))
-            setBinValue(binValue * factor);
-        else {
-            String newValue = (getRealValue() * factor) + "";
+        String newValue = (getRealValue() * factor) + "";
 
-            //We need to convert from dot to comma, in the case of EU Format.
-            // This is because getRealValue to String has dot notation.
-            if(NumberUtil.getSeperator() == ',') newValue = newValue.replace('.', ',');
+        //We need to convert from dot to comma, in the case of EU Format.
+        // This is because getRealValue to String has dot notation.
+        if(NumberUtil.getSeperator() == ',') newValue = newValue.replace('.', ',');
 
-            setRealValue(newValue);
-        }
+        setRealValue(newValue);    
     }
 
     @Override
@@ -595,7 +596,11 @@ public class DataCell implements Serializable  {
         if(this.table.isStaticDataTable() != otherCell.table.isStaticDataTable()) {
             return false;
         }
-
+        
+        if(this.getBitMask() != otherCell.getBitMask()) {
+        	return false;
+        }
+        
         return binValue == otherCell.binValue;
     }
 

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2021 RomRaider.com
+ * Copyright (C) 2006-2022 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/maps/DataCellView.java
+++ b/src/main/java/com/romraider/maps/DataCellView.java
@@ -83,6 +83,9 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
         cell.setDataView(this);
         this.y = cell.getIndexInTable();
         this.setPreferredSize(getSettings().getCellSize());
+        
+        //Once we create a view of the datacell, it should be safe to calculate the value range
+        cell.calcValueRange();
     }
     
     public DataCellView(DataCell cell, TableView view, int x, int y) {
@@ -110,6 +113,7 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
             return;
         }
 
+        tableView.updatePresetPanel();
         this.invalidate();
         setFont(getSettings().getTableFont());
         setText(getCellText());
@@ -167,9 +171,9 @@ public class DataCellView extends JLabel implements MouseListener, Serializable 
             }
         }
 
-        if (t.getMaxAllowedBin() < dataCell.getBinValue()) {
+        if (dataCell.getMaxAllowedBin() < dataCell.getBinValue()) {
             return getSettings().getWarningColor();
-        } else if (t.getMinAllowedBin() > dataCell.getBinValue()) {
+        } else if (dataCell.getMinAllowedBin() > dataCell.getBinValue()) {
             return getSettings().getWarningColor();
         } else {
             // limits not set, scale based on table values

--- a/src/main/java/com/romraider/maps/PresetPanel.java
+++ b/src/main/java/com/romraider/maps/PresetPanel.java
@@ -187,7 +187,6 @@ public class PresetPanel extends JPanel {
 			}
 			
 			table.getTable().calcCellRanges();
-			table.getTable().calcValueRange();
 			repaint();
 		}
 	}

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -499,9 +499,13 @@ public abstract class Table implements Serializable {
 
     abstract public byte[] saveFile(byte[] binData);
 
-    public void setValues(String name, String value) {
-        if(presetManager == null) presetManager = new PresetManager(this);
-        presetManager.setValues(name, value);
+    public void setPresetValues(String name, String value) {
+    	setPresetValues(name, value, 0);
+    }
+    
+    public void setPresetValues(String name, String value, int dataCellOffset) {
+    	if(presetManager == null) presetManager = new PresetManager(this);
+    	presetManager.setPresetValues(name, value, dataCellOffset);
     }
 
     public boolean isBeforeRam() {

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2021 RomRaider.com
+ * Copyright (C) 2006-2022 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,206 +19,56 @@
 
 package com.romraider.maps;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import javax.swing.JCheckBox;
 import com.romraider.util.ByteUtil;
 
-public class TableBitwiseSwitch extends Table {
+public class TableBitwiseSwitch extends TableSwitch {
 	private static final long serialVersionUID = -4887718305447362308L;
-
-	private final Map<String, Integer> controlBits = new HashMap<String, Integer>();
-	private int dataSize = 1;
-	private boolean[] bits_array;
+	private LinkedList<Integer> bits = new LinkedList<Integer>();
+	
 	public TableBitwiseSwitch() {
-		super();
-		storageType = 1;
+		storageType = 1;		
 	}
 
 	@Override
-	public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {
-		int maxBitPosition = ((dataSize * 8) - 1);
-		bits_array = new boolean[maxBitPosition + 1];
-		byte[] input = rom.getBinary();
-		
-		for (int i = 0; i < dataSize; i++) {
-			boolean[] byte_values = ByteUtil.byteToBoolArr(input[storageAddress + i]);
-			for (int j = 0; j < 8; j++) {
-				bits_array[((dataSize - 1 - i) *8)+ j] = byte_values[7-j];
-			}
-		}
-	}
-	
-    //Cleans up all references to avoid data leaks
-    public void clearData() {   	
-    	controlBits.clear();
+    public void populateTable(Rom rom) throws ArrayIndexOutOfBoundsException, IndexOutOfBoundsException {      
+    	if(isStaticDataTable()) return;       
+        validateScaling();
+
+        // temporarily remove lock;
+        boolean tempLock = locked;
+        locked = false;
+
+        if (!beforeRam) {
+            this.ramOffset = rom.getRomID().getRamOffset();
+        }
+
+        setDataSize(bits.size());
+        int i = 0;
+        for (int bit : bits) {
+            data[i] = new DataCell(this, 0, rom); //Offset is always 0
+            data[i].setBitMask(ByteUtil.bitToMask(bit));
+            data[i].updateBinValueFromMemory();
+            i++;
+        }
+
+        // reset locked status
+        locked = tempLock;
+        calcCellRanges();
+
+        //Add Raw Scale
+        addScale(new Scale());
     }
 	
-	public Map<String, Integer> getControlBits() {
-		return controlBits;
-	}
-	
-	public boolean[] getBitsArray() {
-		return bits_array;
-	}
-	
-	@Override
-	public void setName(String name) {
-		super.setName(name);
-	}
-
-	@Override
-	public TableType getType() {
-		return Table.TableType.SWITCH;
-	}
-
-	@Override
-	public byte[] saveFile(byte[] input) {
-
-		for (Entry<String, Integer> entry : controlBits.entrySet()) {
-			int entry_offset = (dataSize - 1) - (entry.getValue() / 8);
-			int bitpos = 7 - (entry.getValue() % 8);
-
-			boolean[] bools = ByteUtil.byteToBoolArr(input[storageAddress + entry_offset]);
-			JCheckBox cb = getButtonByText(entry.getKey());
-			
-			if(cb != null) {
-				bools[bitpos] = cb.isSelected();
-				byte result = ByteUtil.booleanArrayToBit(bools);
-	
-				input[storageAddress + entry_offset] = result;
-			}
-		}
-
-		return input;
-	}
-	
-	//This is bad design
-	private JCheckBox getButtonByText(String text) {
-		TableView v = getTableView();
-		
-		if(v != null) {
-			TableBitwiseSwitchView bv = (TableBitwiseSwitchView)v;
-			
-			for (JCheckBox cb : bv.getCheckboxes()) {
-				if (cb.getText().equalsIgnoreCase(text)) {
-					return cb;
-				}
-			}
-		}
-		
-		return null;
-	}
+    @Override
+    public void clearData() {   
+    	super.clearData();
+    	bits.clear();
+    }	
 	
     @Override
-	public void setValues(String name, String input) {
-		controlBits.put(name, Integer.parseInt(input));
-	}
-
-	public int getValues(String key) {
-		return controlBits.get(key);
-	}
-
-	public Map<String, Integer> getSwitchStates() {
-		return this.controlBits;
-	}
-
-	@Override
-	public boolean isLiveDataSupported() {
-		return false;
-	}
-
-	@Override
-	public boolean equals(Object other) {
-		try {
-			if (null == other) {
-				return false;
-			}
-
-			if (other == this) {
-				return true;
-			}
-
-			if (!(other instanceof TableBitwiseSwitch)) {
-				return false;
-			}
-
-			TableBitwiseSwitch otherTable = (TableBitwiseSwitch) other;
-
-			if ((null == this.getName() && null == otherTable.getName())
-					|| (this.getName().isEmpty() && otherTable.getName().isEmpty())) {
-				;// Skip name compare if name is null or empty.
-			} else if (!this.getName().equalsIgnoreCase(otherTable.getName())) {
-				return false;
-			}
-
-			if (this.getDataSize() != otherTable.getDataSize()) {
-				return false;
-			}
-
-			if (this.getSwitchStates().keySet().equals(otherTable.getSwitchStates().keySet())) {
-				return true;
-			}
-			return false;
-		} catch (Exception ex) {
-			// TODO: Log Exception.
-			return false;
-		}
-	}
-
-	@Override
-	public void setDataSize(int size) {
-		dataSize = size;
-	}
-
-	@Override
-	public int getDataSize() {
-		return dataSize;
-	}
-
-	@Override
-	public void populateCompareValues(Table compareTable) {
-		return; // Do nothing.
-	}
-
-	@Override
-	public void calcCellRanges() {
-		return; // Do nothing.
-	}
-
-	@Override
-	public void setCurrentScale(Scale curScale) {
-		return; // Do nothing.
-	}
-
-	@Override
-	public boolean isButtonSelected() {
-		// TODO Auto-generated method stub
-		return false;
-	}
-
-	static Map<String, Integer> sortByValue(Map<String, Integer> unsortMap) {
-		List<Map.Entry<String, Integer>> list =
-						new LinkedList<Map.Entry<String, Integer>>(unsortMap.entrySet());
-		Collections.sort(list, new Comparator<Map.Entry<String, Integer>>() {
-				public int compare(Map.Entry<String, Integer> o1,
-													 Map.Entry<String, Integer> o2) {
-						return (o1.getValue()).compareTo(o2.getValue());
-				}
-		});
-
-		Map<String, Integer> sortedMap = new LinkedHashMap<String, Integer>();
-		for (Map.Entry<String, Integer> entry : list) {
-				sortedMap.put(entry.getKey(), entry.getValue());
-		}
-
-		return sortedMap;
+	public void setPresetValues(String name, String bitPos) {
+    	bits.add(Integer.parseInt(bitPos));
+    	super.setPresetValues(name, "1", bits.size() - 1);
 	}
 }

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitch.java
@@ -68,7 +68,9 @@ public class TableBitwiseSwitch extends TableSwitch {
 	
     @Override
 	public void setPresetValues(String name, String bitPos) {
-    	bits.add(Integer.parseInt(bitPos));
-    	super.setPresetValues(name, "1", bits.size() - 1);
+    	if (bitPos != null && bitPos.length() > 0) {
+	    	bits.add(Integer.parseInt(bitPos));
+	    	super.setPresetValues(name, "1", bits.size() - 1);
+    	}
 	}
 }

--- a/src/main/java/com/romraider/maps/TableBitwiseSwitchView.java
+++ b/src/main/java/com/romraider/maps/TableBitwiseSwitchView.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2021 RomRaider.com
+ * Copyright (C) 2006-2022 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,121 +19,10 @@
 
 package com.romraider.maps;
 
-import java.awt.BorderLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.ResourceBundle;
-import java.util.Map.Entry;
+public class TableBitwiseSwitchView extends TableSwitchView {
+	private static final long serialVersionUID = 7672148184533172213L;
 
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextArea;
-
-import com.romraider.util.ResourceUtil;
-
-import static javax.swing.JOptionPane.ERROR_MESSAGE;
-import static javax.swing.JOptionPane.showMessageDialog;
-
-public class TableBitwiseSwitchView extends TableView {
-
-	private static final long serialVersionUID = -4887718305447362308L;
-    private static final ResourceBundle rb = new ResourceUtil().getBundle(
-            TableBitwiseSwitch.class.getName());
-	private ArrayList<JCheckBox> checkboxes;
-	private TableBitwiseSwitch table;
-
-	public TableBitwiseSwitchView(TableBitwiseSwitch table) {
-		super(table);
-		this.table = table;
-		removeAll();
-		setLayout(new BorderLayout());
-		checkboxes = new ArrayList<JCheckBox>();
-		populateTableVisual();
-	}
-
-	@Override
-	public void populateTableVisual() {
-		int maxBitPosition = ((table.getDataSize() * 8) - 1);
-		JPanel radioPanel = new JPanel(new GridLayout(0, 1));
-		radioPanel.add(new JLabel("  " + getName()));
-
-		for (Entry<String, Integer> entry : TableBitwiseSwitch.sortByValue(table.getControlBits()).entrySet()) {
-			if (entry.getValue() > maxBitPosition) {
-				String mismatch = MessageFormat.format(
-						rb.getString("OUTOFRANGE"), table.getName());
-				showMessageDialog(this, mismatch,
-				        rb.getString("DEFERROR"), ERROR_MESSAGE);
-				break;
-			} else {
-				JCheckBox cb = new JCheckBox(entry.getKey());
-				cb.setSelected(table.getBitsArray()[entry.getValue()]);
-				checkboxes.add(cb);
-				radioPanel.add(cb);
-			}
-		}
-		add(radioPanel, BorderLayout.CENTER);
-		
-		JTextArea descriptionArea = new JTextArea(table.getDescription());
-		descriptionArea.setOpaque(false);
-		descriptionArea.setEditable(false);
-		descriptionArea.setWrapStyleWord(true);
-		descriptionArea.setLineWrap(true);
-		descriptionArea.setMargin(new Insets(0, 5, 5, 5));
-
-		add(descriptionArea, BorderLayout.SOUTH);
-	}
-
-	public ArrayList<JCheckBox> getCheckboxes() {
-		return checkboxes;
-	}
-	
-	@Override
-	public void setName(String name) {
-		super.setName(name);
-	}
-
-	@Override
-	public void cursorUp() {
-	}
-
-	@Override
-	public void cursorDown() {
-	}
-
-	@Override
-	public void cursorLeft() {
-	}
-
-	@Override
-	public void cursorRight() {
-	}
-
-	@Override
-	public void shiftCursorUp() {
-	}
-
-	@Override
-	public void shiftCursorDown() {
-	}
-
-	@Override
-	public void shiftCursorLeft() {
-	}
-
-	@Override
-	public void shiftCursorRight() {
-	}
-
-	@Override
-	public void drawTable() {
-		return; // Do nothing.
-	}
-
-	@Override
-	public void updateTableLabel() {
-		return; // Do nothing.
+	public TableBitwiseSwitchView(TableBitwiseSwitch t) {
+		super(t);
 	}
 }

--- a/src/main/java/com/romraider/maps/TableSwitchView.java
+++ b/src/main/java/com/romraider/maps/TableSwitchView.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2020 RomRaider.com
+ * Copyright (C) 2006-2022 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2021 RomRaider.com
+ * Copyright (C) 2006-2022 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main/java/com/romraider/maps/TableView.java
+++ b/src/main/java/com/romraider/maps/TableView.java
@@ -557,10 +557,15 @@ public abstract class TableView extends JPanel implements Serializable {
     public String toString() {
         return table.toString();
     }
-     
+    
+    public void updatePresetPanel() {
+    	if(presetPanel != null)
+    		presetPanel.repaint();
+    }
+    
     public void drawTable() {
     	updateTableLabel();
-    	
+
     	if(data!=null && !isHidden()) {
 	        for(DataCellView cell : data) {
 	            if(null != cell) {

--- a/src/main/java/com/romraider/util/ByteUtil.java
+++ b/src/main/java/com/romraider/util/ByteUtil.java
@@ -143,6 +143,10 @@ public final class ByteUtil {
     	
     	return counter;
     }
+    
+    public static int bitToMask(int bit) {
+    	return  1 << bit;
+    }
 
     private static int[] computeFailure(byte[] pattern) {
         int[] failure = new int[pattern.length];

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -293,11 +293,11 @@ public class TableScaleUnmarshaller {
                     table.setDescription(unmarshallText(n));
 
                 } else if (n.getNodeName().equalsIgnoreCase("state")) {
-                    table.setValues(
+                    table.setPresetValues(
                                 unmarshallAttribute(n, "name", ""),
                                 unmarshallAttribute(n, "data", "0"));
                 } else if (n.getNodeName().equalsIgnoreCase("bit")) {
-                    table.setValues(
+                    table.setPresetValues(
                             unmarshallAttribute(n, "name", ""),
                             unmarshallAttribute(n, "position", "0"));
 

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -299,7 +299,7 @@ public class TableScaleUnmarshaller {
                 } else if (n.getNodeName().equalsIgnoreCase("bit")) {
                     table.setPresetValues(
                             unmarshallAttribute(n, "name", ""),
-                            unmarshallAttribute(n, "position", "0"));
+                            unmarshallAttribute(n, "position", ""));
 
                 } else { /* unexpected element in Table (skip) */
                 }


### PR DESCRIPTION
Hi,
this fixes #143 and #128. Bitwise switches were storing their data in the GUI and the code was not very nice. I have refactored it so that it uses hidden DataCells. DataCells can now have individual masks. When you create a Bitwise Table you are creating multiple DataCells at the same location with different masks. The compare feature should also work for them now and the order of the checkboxes is dependent of the definition order.

If you find anything wrong with this, let me know!