### PR TITLE
Fix logger loading from editor, Option for automatic logger connection

### DIFF
--- a/i18n/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.properties
+++ b/i18n/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.properties
@@ -13,6 +13,7 @@ OUTLOCATION = Log File Output Location ...
 PROTOOPTIONS = Select Logging Protocol Options ...
 PROTOOPTIONSTT = Select to switch logging communications protocol
 DEFOGGERSW = Control File Logging With Defogger Switch
+AUTOCONNECT= Automatically Connect On Startup
 COMREFRESH = Enable COM port Auto Refresh
 COMREFRESHTT = Select to enable automatic COM port refreshing
 ELM327ENABLED = Enable ELM327 OBD Support

--- a/src/main/java/com/romraider/Settings.java
+++ b/src/main/java/com/romraider/Settings.java
@@ -217,6 +217,7 @@ public class Settings implements Serializable {
     private boolean fileLoggingAbsoluteTimestamp;
     private String logfileNameText;
     private boolean logExternalsOnly;
+    private boolean autoConnectOnStartup = true;
     private static String userLocale = SYSTEM_NUMFORMAT;
 
     private Dimension loggerWindowSize = new Dimension(1000, 600);
@@ -567,6 +568,14 @@ public class Settings implements Serializable {
         this.loggerPortDefault = loggerPortDefault;
     }
 
+    public void setAutoConnectOnStartup(boolean value) {
+    	autoConnectOnStartup = value;
+    }
+    
+    public boolean getAutoConnectOnStartup() {
+    	return autoConnectOnStartup;
+    }
+    
     public void setLoggerProtocol(String protocol) {
         Settings.loggerProtocol = protocol;
     }

--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -31,6 +31,7 @@ import static javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED;
 import static javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER;
 import static javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS;
 import static javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED;
+import static com.romraider.util.ThreadUtil.runAsDaemon;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -71,6 +72,8 @@ import javax.swing.tree.TreePath;
 import com.romraider.ECUExec;
 import com.romraider.Settings;
 import com.romraider.logger.ecu.EcuLogger;
+import com.romraider.logger.ecu.ui.handler.table.TableUpdateHandler;
+import com.romraider.logger.ecu.ui.playback.PlaybackManagerImpl;
 import com.romraider.maps.Rom;
 import com.romraider.maps.Table;
 import com.romraider.maps.Table1D;
@@ -100,6 +103,7 @@ import com.romraider.swing.TableToolBar;
 import com.romraider.swing.TableTreeNode;
 import com.romraider.util.ResourceUtil;
 import com.romraider.util.SettingsManager;
+import com.romraider.util.ThreadUtil;
 import com.romraider.xml.ConversionLayer.ConversionLayer;
 
 public class ECUEditor extends AbstractFrame {
@@ -613,9 +617,12 @@ public class ECUEditor extends AbstractFrame {
         	return;
         }
         else {
-            setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-			ECUExec.openLogger(DISPOSE_ON_CLOSE, new String[] {"-logger"});	   
-			setCursor(null);
+        	ThreadUtil.runAsDaemon(new Runnable() {
+                @Override
+                public void run() {
+                	ECUExec.openLogger(DISPOSE_ON_CLOSE, new String[] {"-logger"});
+                }
+            }); 
         }
     }
 

--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -31,8 +31,6 @@ import static javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED;
 import static javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER;
 import static javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS;
 import static javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED;
-import static com.romraider.util.ThreadUtil.runAsDaemon;
-
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Cursor;
@@ -72,8 +70,6 @@ import javax.swing.tree.TreePath;
 import com.romraider.ECUExec;
 import com.romraider.Settings;
 import com.romraider.logger.ecu.EcuLogger;
-import com.romraider.logger.ecu.ui.handler.table.TableUpdateHandler;
-import com.romraider.logger.ecu.ui.playback.PlaybackManagerImpl;
 import com.romraider.maps.Rom;
 import com.romraider.maps.Table;
 import com.romraider.maps.Table1D;

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -2073,6 +2073,10 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
         getSettings().setRefreshMode(refreshMode);
         refresher.setRefreshMode(refreshMode);
     }
+    
+    public void setAutoConnect(boolean connect) {
+        getSettings().setAutoConnectOnStartup(connect);
+    }
 
 	public void setElmEnabled(Boolean value) {
         getSettings().setElm327Enabled(value);
@@ -2102,13 +2106,12 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
 
     //**********************************************************************
 
-
     public static void startLogger(int defaultCloseOperation, ECUEditor ecuEditor, String[] args) {
         touchEnabled = setTouchEnabled(args);
         boolean fullscreen = containsFullScreenArg(args);
         EcuLogger ecuLogger = getEcuLogger(ecuEditor);
         createAndShowGui(defaultCloseOperation, ecuLogger, fullscreen);
-        if (!ecuLogger.isLogging()) ecuLogger.startLogging();
+        if (ecuLogger.getSettings().getAutoConnectOnStartup() && !ecuLogger.isLogging()) ecuLogger.startLogging();
     }
 
     private static boolean containsFullScreenArg(String... args) {

--- a/src/main/java/com/romraider/logger/ecu/EcuLogger.java
+++ b/src/main/java/com/romraider/logger/ecu/EcuLogger.java
@@ -373,7 +373,6 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
             progressBar.setValue(100);
             initDataUpdateHandlers();
             startPortRefresherThread();
-            if (!isLogging()) startLogging();
             startStatus.dispose();
         }
         else {
@@ -390,7 +389,6 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
             ecuEditor.getStatusPanel().update(rb.getString("COMPLETE"), 100);
             initDataUpdateHandlers();
             startPortRefresherThread();
-            if (!isLogging()) startLogging();
             ecuEditor.getStatusPanel().update(rb.getString("READY"),0);
         }
         this.toFront();
@@ -517,7 +515,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
         long start = currentTimeMillis();
         while (!refresher.isStarted()) {
             checkSerialPortRefresherTimeout(start);
-            sleep(100);
+            sleep(5);
         }
     }
 
@@ -2110,6 +2108,7 @@ public final class EcuLogger extends AbstractFrame implements MessageListener {
         boolean fullscreen = containsFullScreenArg(args);
         EcuLogger ecuLogger = getEcuLogger(ecuEditor);
         createAndShowGui(defaultCloseOperation, ecuLogger, fullscreen);
+        if (!ecuLogger.isLogging()) ecuLogger.startLogging();
     }
 
     private static boolean containsFullScreenArg(String... args) {

--- a/src/main/java/com/romraider/logger/ecu/comms/io/connection/LoggerConnectionFactory.java
+++ b/src/main/java/com/romraider/logger/ecu/comms/io/connection/LoggerConnectionFactory.java
@@ -24,11 +24,9 @@ import static com.romraider.io.connection.ConnectionManagerFactory.getManager;
 import com.romraider.io.connection.ConnectionProperties;
 import com.romraider.io.elm327.ElmConnectionManager;
 import com.romraider.logger.ecu.exception.UnsupportedProtocolException;
-import com.romraider.logger.ecu.comms.io.connection.ELMOBDLoggerConnection;
 
 public final class LoggerConnectionFactory {
-    private LoggerConnectionFactory() {
-    }
+    private LoggerConnectionFactory() {}
 
     public static LoggerConnection getConnection(
             final String protocolName,

--- a/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/EcuLoggerMenuBar.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2020 RomRaider.com
+ * Copyright (C) 2006-2022 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,6 +59,7 @@ import javax.swing.JSeparator;
 
 import com.romraider.Settings;
 import com.romraider.logger.ecu.EcuLogger;
+import com.romraider.logger.ecu.ui.swing.menubar.action.AutoConnectAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.ComPortAutoRefreshAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.DisconnectAction;
 import com.romraider.logger.ecu.ui.swing.menubar.action.ElmEnabledAction;
@@ -121,6 +122,9 @@ public class EcuLoggerMenuBar extends JMenuBar {
         fileLoggingControl.setSelected(false);
         settingsMenu.add(fileLoggingControl);
         logger.getComponentList().put("fileLoggingControl", fileLoggingControl);
+        RadioButtonMenuItem autoConnect = new RadioButtonMenuItem(rb.getString("AUTOCONNECT"), VK_A, getKeyStroke(VK_A, CTRL_MASK), new AutoConnectAction(logger), logger.getSettings().getAutoConnectOnStartup());
+        autoConnect.setToolTipText(rb.getString("AUTOCONNECT"));
+        settingsMenu.add(autoConnect);
         RadioButtonMenuItem autoRefresh = new RadioButtonMenuItem(rb.getString("COMREFRESH"), VK_E, getKeyStroke(VK_E, CTRL_MASK), new ComPortAutoRefreshAction(logger), logger.getSettings().getRefreshMode());
         autoRefresh.setToolTipText(rb.getString("COMREFRESHTT"));
         settingsMenu.add(autoRefresh);

--- a/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/action/AutoConnectAction.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/swing/menubar/action/AutoConnectAction.java
@@ -1,0 +1,39 @@
+/*
+ * RomRaider Open-Source Tuning, Logging and Reflashing
+ * Copyright (C) 2006-2022 RomRaider.com
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package com.romraider.logger.ecu.ui.swing.menubar.action;
+
+import com.romraider.logger.ecu.EcuLogger;
+import com.romraider.swing.menubar.action.AbstractAction;
+import java.awt.event.ActionEvent;
+
+public final class AutoConnectAction extends AbstractAction {
+
+    public AutoConnectAction(EcuLogger logger) {
+        super(logger);
+    }
+
+    public void actionPerformed(ActionEvent actionEvent) {
+        try {
+            logger.getSettings().setAutoConnectOnStartup((Boolean) getValue(SELECTED_KEY));
+        } catch (Exception e) {
+            logger.reportError(e);
+        }
+    }
+}

--- a/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoControlPanel.java
+++ b/src/main/java/com/romraider/logger/ecu/ui/tab/dyno/DynoControlPanel.java
@@ -1107,13 +1107,13 @@ public final class DynoControlPanel extends JPanel {
     }
 
     private JButton buildOpenReferenceButton() {
-        final JFileChooser openFile = new JFileChooser();
-        if (path != null) openFile.setCurrentDirectory(new File(path));
         final JButton openButton = new JButton(rb.getString("OPEN"));
 
         openButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
+                final JFileChooser openFile = new JFileChooser();
+                if (path != null) openFile.setCurrentDirectory(new File(path));
                 int returnVal = openFile.showOpenDialog(openButton);
 
                 if (returnVal == JFileChooser.APPROVE_OPTION) {
@@ -1168,13 +1168,14 @@ public final class DynoControlPanel extends JPanel {
     }
 
     private JButton buildSaveReferenceButton() {
-        final JFileChooser openFile = new JFileChooser();
-        if (path != null) openFile.setCurrentDirectory(new File(path));
         final JButton saveButton = new JButton(rb.getString("SAVE"));
 
         saveButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent actionEvent) {
+                final JFileChooser openFile = new JFileChooser();
+                if (path != null) openFile.setCurrentDirectory(new File(path));
+                
                 int returnVal = openFile.showSaveDialog(saveButton);
 
                 if (returnVal == JFileChooser.APPROVE_OPTION) {

--- a/src/main/java/com/romraider/xml/DOMSettingsBuilder.java
+++ b/src/main/java/com/romraider/xml/DOMSettingsBuilder.java
@@ -322,6 +322,11 @@ public final class DOMSettingsBuilder {
         IIOMetadataNode loggerSettings = new IIOMetadataNode("logger");
         loggerSettings.setAttribute("locale", settings.getLocale());
 
+        // Automatically connect the logger on startup
+        IIOMetadataNode autoConnect = new IIOMetadataNode("autoConnectOnStartup");
+        autoConnect.setAttribute("value", "" + settings.getAutoConnectOnStartup());
+        loggerSettings.appendChild(autoConnect);
+        
         // serial connection
         IIOMetadataNode serial = new IIOMetadataNode("serial");
         serial.setAttribute("port", validateAttr(settings.getLoggerPortDefault()));

--- a/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/DOMSettingsUnmarshaller.java
@@ -260,7 +260,8 @@ public final class DOMSettingsUnmarshaller {
             if (n.getNodeType() == ELEMENT_NODE && n.getNodeName().equalsIgnoreCase("serial")) {
                 settings.setLoggerPortDefault(unmarshallAttribute(n, "port", ""));
                 settings.setRefreshMode(unmarshallAttribute(n, "refresh", false));
-
+            } else if (n.getNodeType() == ELEMENT_NODE && n.getNodeName().equalsIgnoreCase("autoConnectOnStartup")) {
+            	settings.setAutoConnectOnStartup(unmarshallAttribute(n, "value", true));
             } else if (n.getNodeType() == ELEMENT_NODE && n.getNodeName().equalsIgnoreCase("protocol")) {
                 settings.setLoggerProtocol(unmarshallAttribute(n, "name", "SSM"));
                 settings.setTransportProtocol(unmarshallAttribute(n, "transport", "ISO9141"));


### PR DESCRIPTION
Hi,
this fixes #169. I also made some minor changes for a tiny bit faster loading.

Time needed to launch the logger on my machine:

![image](https://user-images.githubusercontent.com/9764527/162525955-3307caf8-55ee-4eb7-ade5-5fdea2eb8058.png)

Bootstrap(378ms) is mostly slowed down by the constructor of MafTabImpl (225ms) and DynoTabImpl(179ms) when setting up the chart. LoadLoggerPlugins(153ms) is mainly slowed down by the InfKitDataSource constructor for finding the Phidget Kits. initUserInterface(123ms) is mostly slowed down by the constructor of the EcuLoggerMenuBar.

I also added a button to the logger which en- or disables the automatic connect on startup. Default is true, so it should behave like before.

