### PR TITLE
Fix Whitespace Issue in Preset Manager

### DIFF
--- a/src/main/java/com/romraider/maps/PresetManager.java
+++ b/src/main/java/com/romraider/maps/PresetManager.java
@@ -98,8 +98,10 @@ public class PresetManager {
 	
 		data =  data.trim();
 		
-		for (String s : data.split(data.contains(",") ? "," : " ")) {				
-			entry.data.add(parseStringToInt(s));
+		for (String s : data.split(data.contains(",") ? "," : " ")) {
+			if(!s.isEmpty()){
+				entry.data.add(parseStringToInt(s));
+			}
 		}
 		
 		presets.add(entry);


### PR DESCRIPTION
Hi,
this fixes #172. Problem in that definition was the extra whitespace in the middle. The values are split by whitespace and that created an empty string which is hard to convert to a number.


Cheers!