### PR TITLE
Fix SaxParser non-ascii config path exception

### DIFF
--- a/src/main/java/com/romraider/logger/ecu/definition/EcuDataLoaderImpl.java
+++ b/src/main/java/com/romraider/logger/ecu/definition/EcuDataLoaderImpl.java
@@ -95,11 +95,12 @@ public final class EcuDataLoaderImpl implements EcuDataLoader {
         boolean valid = true;
         
         try {
-            InputStream inputStream = new BufferedInputStream(new FileInputStream(new File(loggerConfigFilePath)));
+            //InputStream inputStream = new BufferedInputStream(new FileInputStream(new File(loggerConfigFilePath)));
+            File loggerConfigFile = new File(loggerConfigFilePath);
             try {
                 LoggerDefinitionHandler handler = new LoggerDefinitionHandler(
                         protocol, fileLoggingControllerSwitchId, ecuInit);
-                getSaxParser().parse(inputStream, handler, loggerConfigFilePath);
+                getSaxParser().parse(loggerConfigFile, handler);
                               
                 ecuParameters = handler.getEcuParameters();
                 ecuSwitches = handler.getEcuSwitches();
@@ -117,7 +118,7 @@ public final class EcuDataLoaderImpl implements EcuDataLoader {
                 			keySet().iterator().next().getId());               	               	
                 }                              
             } finally {
-                inputStream.close();
+                //inputStream.close();
             }
         }/* catch (FileNotFoundException fnfe) {
             throw new ConfigurationException(MessageFormat.format(

--- a/src/main/java/com/romraider/logger/ecu/definition/EcuDataLoaderImpl.java
+++ b/src/main/java/com/romraider/logger/ecu/definition/EcuDataLoaderImpl.java
@@ -60,15 +60,9 @@ public final class EcuDataLoaderImpl implements EcuDataLoader {
     public void loadEcuDefsFromXml(File ecuDefsFile) {
         checkNotNull(ecuDefsFile, "ecuDefsFile");
         try {
-            InputStream inputStream = new BufferedInputStream(
-                    new FileInputStream(ecuDefsFile));
-            try {
                 EcuDefinitionHandler handler = new EcuDefinitionHandler(ecuDefsFile);
-                getSaxParser().parse(inputStream, handler, ecuDefsFile.getAbsolutePath());
+                getSaxParser().parse(ecuDefsFile, handler);
                 ecuDefinitionMap = handler.getEcuDefinitionMap();
-            } finally {
-                inputStream.close();
-            }
         } catch (SAXParseException spe) {
             // catch general parsing exception - enough people don't
             // unzip the defs that a better error message is in order
@@ -95,9 +89,7 @@ public final class EcuDataLoaderImpl implements EcuDataLoader {
         boolean valid = true;
         
         try {
-            //InputStream inputStream = new BufferedInputStream(new FileInputStream(new File(loggerConfigFilePath)));
-            File loggerConfigFile = new File(loggerConfigFilePath);
-            try {
+                File loggerConfigFile = new File(loggerConfigFilePath);
                 LoggerDefinitionHandler handler = new LoggerDefinitionHandler(
                         protocol, fileLoggingControllerSwitchId, ecuInit);
                 getSaxParser().parse(loggerConfigFile, handler);
@@ -116,10 +108,7 @@ public final class EcuDataLoaderImpl implements EcuDataLoader {
                 	s.setLoggerProtocol(protocolList.keySet().iterator().next());
                 	s.setTransportProtocol(protocolList.values().iterator().next().
                 			keySet().iterator().next().getId());               	               	
-                }                              
-            } finally {
-                //inputStream.close();
-            }
+                }
         }/* catch (FileNotFoundException fnfe) {
             throw new ConfigurationException(MessageFormat.format(
                     rb.getString("LOGFNF"), loggerConfigFilePath));

--- a/src/main/java/com/romraider/logger/ecu/profile/UserProfileLoaderImpl.java
+++ b/src/main/java/com/romraider/logger/ecu/profile/UserProfileLoaderImpl.java
@@ -43,14 +43,10 @@ public final class UserProfileLoaderImpl implements UserProfileLoader {
         checkNotNullOrEmpty(userProfileFilePath, "userProfileFilePath");
         LOGGER.info("Loading profile: " + userProfileFilePath);
         try {
-            InputStream inputStream = new BufferedInputStream(new FileInputStream(new File(userProfileFilePath)));
-            try {
+                File userProfileFile = new File(userProfileFilePath);
                 UserProfileHandler handler = new UserProfileHandler();
-                getSaxParser().parse(inputStream, handler);
+                getSaxParser().parse(userProfileFile, handler);
                 return handler.getUserProfile();
-            } finally {
-                inputStream.close();
-            }
         } catch (FileNotFoundException fileException) {
         	if(fileException.getMessage().contains("profile.dtd")) {
         		LOGGER.info("Profile.dtd missing, applying patch: " + userProfileFilePath);


### PR DESCRIPTION
com.romraider.logger.ecu.exception.ConfigurationException: com.sun.org.apache.xerces.internal.util.URI$MalformedURIException: Path contains invalid character: П