### PR TITLE
Change "state" node processing

### DIFF
--- a/src/main/java/com/romraider/maps/PresetManager.java
+++ b/src/main/java/com/romraider/maps/PresetManager.java
@@ -91,7 +91,7 @@ public class PresetManager {
 		}
 	}
 
-	public void setPresetValues(String name, String data, int dataCellOffset, boolean isBitMask) {
+	private PresetEntry createPresetEntryValue(String name, String data, int dataCellOffset, boolean isBitMask) {
 		PresetEntry entry = new PresetEntry();
 		entry.name = name;
 		entry.data = new LinkedList<Integer>();
@@ -106,7 +106,31 @@ public class PresetManager {
 			}
 		}
 
+		return entry;
+	}
+
+	//Don't check for duplicate names, just add
+	public void setPresetValues(String name, String data, int dataCellOffset, boolean isBitMask) {
+		PresetEntry entry = createPresetEntryValue(name, data, dataCellOffset, isBitMask);
+
 		presets.add(entry);
+	}
+
+	//Check for duplicate names, then replace if exist or add otherwise
+	public void addPresetValue(String name, String data, int dataCellOffset, boolean isBitMask) {
+		PresetEntry oldEntry = null;
+		PresetEntry newEntry = createPresetEntryValue(name, data, dataCellOffset, isBitMask);
+
+		for (int i = 0; i < presets.size(); i++) {
+			if (presets.get(i).name.equalsIgnoreCase(newEntry.name)){
+				oldEntry = presets.set(i, newEntry);
+				break;
+			}
+		}
+
+		if (oldEntry == null) {
+			presets.add(newEntry);
+		}
 	}
 
 	public LinkedList<PresetEntry> getPresets(){

--- a/src/main/java/com/romraider/maps/Table.java
+++ b/src/main/java/com/romraider/maps/Table.java
@@ -497,14 +497,28 @@ public abstract class Table implements Serializable, Comparable<Table> {
         }
     }
 
+    //Don't check for duplicate names, just add
     public void setPresetValues(String name, String value) {
     	if(presetManager == null) presetManager = new PresetManager(this);
     	presetManager.setPresetValues(name, value, 0, false);
     }
 
+    //Don't check for duplicate names, just add
     public void setPresetValues(String name, String value, int dataCellOffset) {
     	if(presetManager == null) presetManager = new PresetManager(this);
     	presetManager.setPresetValues(name, value, dataCellOffset, true);
+    }
+
+    //Check for duplicate names, then replace if exist or add otherwise
+    public void addPresetValue(String name, String value) {
+    	if(presetManager == null) presetManager = new PresetManager(this);
+    	presetManager.addPresetValue(name, value, 0, false);
+    }
+
+    //Check for duplicate names, then replace if exist or add otherwise
+    public void addPresetValue(String name, String value, int dataCellOffset) {
+    	if(presetManager == null) presetManager = new PresetManager(this);
+    	presetManager.addPresetValue(name, value, dataCellOffset, true);
     }
 
     public boolean isBeforeRam() {

--- a/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
+++ b/src/main/java/com/romraider/xml/TableScaleUnmarshaller.java
@@ -285,7 +285,8 @@ public class TableScaleUnmarshaller {
                     table.setDescription(unmarshallText(n));
 
                 } else if (n.getNodeName().equalsIgnoreCase("state")) {
-                    table.setPresetValues(
+                    //Check for duplicate names, then replace if exist or add otherwise
+                    table.addPresetValue(
                                 unmarshallAttribute(n, "name", ""),
                                 unmarshallAttribute(n, "data", "0"));
                 } else if (n.getNodeName().equalsIgnoreCase("bit")) {


### PR DESCRIPTION
`Switch` table may contain inner `state` nodes. When one wants to modify already existing `state` node (which could be defined in included ROM definitions, for example), RomRaider adds a new node with the same name instead of modifying already existing, like it does with `X Axis` etc. This patch checks if `state` node with same name exists and replaces it or adds it otherwise.