### PR TITLE
Fix VDF scaling name error; Fix save definition bug

### DIFF
--- a/src/main/java/com/romraider/editor/ecu/ECUEditor.java
+++ b/src/main/java/com/romraider/editor/ecu/ECUEditor.java
@@ -285,7 +285,7 @@ public class ECUEditor extends AbstractFrame {
             if (userSelection == JFileChooser.APPROVE_OPTION) {
                 File fileToSave = fileChooser.getSelectedFile();
 
-                if(!fileToSave.getName().endsWith(".xml") ||!fileToSave.getName().endsWith(".XML"))
+                if(!fileToSave.getName().toLowerCase().endsWith(".xml"))
                         fileToSave = new File(fileToSave.getAbsoluteFile() + ".xml");
 
                 String s = ConversionLayer.convertDocumentToString(r.getDocument());

--- a/src/main/java/com/romraider/xml/ConversionLayer/VDFConversionLayer.java
+++ b/src/main/java/com/romraider/xml/ConversionLayer/VDFConversionLayer.java
@@ -262,7 +262,6 @@ public class VDFConversionLayer extends ConversionLayer {
 		table.setAttribute("type", "1D");
 
 		Element scaling = doc.createElement("scaling");
-		scaling.setAttribute("name", "Default");
 		scaling.setAttribute("expression", expression);
 		scaling.setAttribute("units", unit);
 		scaling.setAttribute("format", "0.##");
@@ -440,7 +439,6 @@ public class VDFConversionLayer extends ConversionLayer {
 			table.setAttribute("skipCells", Integer.toString(skipCells));
 
 		Element scaling = doc.createElement("scaling");
-		scaling.setAttribute("name", "Default");
 		scaling.setAttribute("expression", expression);
 		scaling.setAttribute("units", is2DTable ? (sizeX == 1 ? nameAxis1 : nameAxis2) : "");
 		scaling.setAttribute("format", "0.##");


### PR DESCRIPTION
Hi,
this fixes a issue in the VDF loader, where <scaling name="XY" is currently implemented. It also fixes a bug when exporting definitions. It always added a ".xml" even if the file already ended with that.

Cheers,
Robin