### PR TITLE
Fix serial RTS for Openport 1.3 cables; fixes #217

### DIFF
--- a/src/main/java/com/romraider/io/serial/connection/SerialConnectionImpl.java
+++ b/src/main/java/com/romraider/io/serial/connection/SerialConnectionImpl.java
@@ -204,7 +204,7 @@ public class SerialConnectionImpl implements SerialConnection {
             	throw new ConfigurationException("Connection properties");
             if (!serialPort.setComPortTimeouts(TIMEOUT_READ_SEMI_BLOCKING, 0, 0))
             	throw new ConfigurationException("Timeout values");
-            if (!serialPort.setRTS())
+            if (!serialPort.clearRTS())
             	throw new ConfigurationException("RTS value");
         } catch (ConfigurationException e) {
             throw new UnsupportedOperationException(e);


### PR DESCRIPTION
I'd like to thank @dschultzca for invaluable assistance in #217. This seems to be working the best for me right now. Logger connects quickly and is able to reliably remain connected even in fast-polling mode, but there are some caveats.

- The `serialPort.clearRTS()` on init is the principal fix here but that alone is still incredibly janky. I believe that `serialPort.setRTS()` on close makes things better but there are still occasional connect loops lasting 7-10 tries before success. Without setting RTS on close the next connection seems to be unstable and fail randomly after several seconds. (disregard any mention of driver buffer sizes in #217 as I've defaulted everything back at this point). This is reproduced after ECU power off/on, USB unplug/plug, or Logger open/close or any combination thereof. 

- This works for jSerialComm 2.9.3 pretty reliably but slightly worse with 2.10.3. Sometimes connect loops last longer and restarting logger is more efficient than waiting.

- Reading DTCs and related accoutrements is unreliable, and can jank the logging connection, but eventually works if you try 7-10 times. (sound familiar?)

- I don't know how this affects other cables like vagcoms which currently work without this patch. I can only attest to Openport 1.3 on windows plus the details listed in #217.

- I can add sibling `clearDTR()` and `setDTR()` adjacent to the RTS calls if you think it's appropriate but I couldn't prove it had any effect for my own case.

I still think there's a missing piece of the puzzle here, but this is a major step above nothing at all.