### PR TITLE
Ignore spaces in definition check

### DIFF
--- a/customize/nameSequences.properties
+++ b/customize/nameSequences.properties
@@ -1,4 +1,4 @@
-RomRaider = <roms> 
+RomRaider = <roms>
 Profile = <profile
 Dyno = <dyno>
 Logger = <logger


### PR DESCRIPTION
Hi,
currently the roms tag is actually never found, because there is a space in the properties file. I went with a trim(), should be more reliable and less error prone.

Cheers,
Robin