### PR TITLE
updates the vscode doc for recent setup on windows

### DIFF
--- a/docs/Building_RomRaider_VSCode.md
+++ b/docs/Building_RomRaider_VSCode.md
@@ -23,6 +23,10 @@ Here are steps to setup Visual Studio Code to build and debug RomRaider.
 	> - For the value use the unzipped ANT path from the previous step. For Example: 'C:\Users\<USERNAME>\ANT'
 	> - If you do not know how to add a environment variable, see: https://docs.oracle.com/javase/tutorial/essential/environment/paths.html
 
+1. Add '**JRE_DIR**' as a System Environment variable excluding the quotes.
+	> - For the value use the directory from the Java install. For Example: 'C:\Program Files (x86)\Java\jre-1.8'
+	> - If you do not know how to add a environment variable, see: https://docs.oracle.com/javase/tutorial/essential/environment/paths.html
+
 1. Edit the existing '**PATH**' System Environment, add the directory you unzipped ANT to with the \bin directory appended.
 	> For Example: 'C:\Users\<USERNAME>\ANT\bin'
 		


### PR DESCRIPTION
This is something I ran into trying to setup on Win10 today on a PC that has not been previously configured for any development.
I found this in the `build.xml` file and was able to set the `JRE_DIR` to get this building and running locally.
```
<condition property="bootclasspath.dir" value="${env.JRE_DIR}/lib" 
                                 else="C:\Program Files (x86)\Java\jdk1.6.0_45\jre\lib">
       <isset property="env.JRE_DIR" />
 </condition>
 ```
 
 I hope this is helpful for others getting setup.
       