### PR TITLE
Improve Checksum Fix processing

### DIFF
--- a/src/main/java/com/romraider/maps/RomChecksum.java
+++ b/src/main/java/com/romraider/maps/RomChecksum.java
@@ -49,9 +49,16 @@ public class RomChecksum {
     private static void calculateRomChecksum(byte[] input, int storageAddress, int dataSize, int offset) {
         storageAddress = storageAddress - offset;
         for (int i = storageAddress; i < storageAddress + dataSize; i+=12) {
+            int startAddr = (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true);
+            int endAddr   = (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true);
+            int off = offset;
+            //0 means checksum is disabled, keep it
+            if (startAddr == 0 && endAddr == 0) {
+                off = 0;
+            }
             byte[] newSum = calculateChecksum(input,
-                    (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true) - offset,
-                    (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true) - offset);
+                    startAddr - off,
+                    endAddr   - off);
             System.arraycopy(newSum, 0, input, i + 8, 4);
         }
     }
@@ -62,9 +69,16 @@ public class RomChecksum {
         int[] results = new int[dataSize / 12];
         int j = 0;
         for (int i = storageAddress; i < storageAddress + dataSize; i+=12) {
-            int startAddr = (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true) - offset;
-            int endAddr   = (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true) - offset;
+            int startAddr = (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true);
+            int endAddr   = (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true);
             int diff      = (int)parseByteValue(input, Settings.Endian.BIG, i+8, 4, true);
+            int off = offset;
+            //0 means checksum is disabled, keep it
+            if (startAddr == 0 && endAddr == 0) {
+                off = 0;
+            }
+            startAddr -= off;
+            endAddr   -= off;
             if (j == 0 &&
                     startAddr == 0 &&
                     endAddr   == 0 &&

--- a/src/main/java/com/romraider/maps/RomChecksum.java
+++ b/src/main/java/com/romraider/maps/RomChecksum.java
@@ -26,22 +26,44 @@ import com.romraider.Settings;
 
 public class RomChecksum {
 
-    public static void calculateRomChecksum(byte[] input, int storageAddress, int dataSize) {
+    public static void calculateRomChecksum(byte[] input, Table table)
+    {
+        calculateRomChecksum(
+                    input,
+                    table.getStorageAddress(),
+                    table.getDataSize(),
+                    table.getRamOffset()
+        );
+    }
+
+    public static int validateRomChecksum(byte[] input, Table table)
+    {
+        return validateRomChecksum(
+                    input,
+                    table.getStorageAddress(),
+                    table.getDataSize(),
+                    table.getRamOffset()
+        );
+    }
+
+    private static void calculateRomChecksum(byte[] input, int storageAddress, int dataSize, int offset) {
+        storageAddress = storageAddress - offset;
         for (int i = storageAddress; i < storageAddress + dataSize; i+=12) {
             byte[] newSum = calculateChecksum(input,
-                    (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true),
-                    (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true));
+                    (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true) - offset,
+                    (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true) - offset);
             System.arraycopy(newSum, 0, input, i + 8, 4);
         }
     }
 
-    public static int validateRomChecksum(byte[] input, int storageAddress, int dataSize) {
+    private static int validateRomChecksum(byte[] input, int storageAddress, int dataSize, int offset) {
+        storageAddress = storageAddress - offset;
         int result = 0;
         int[] results = new int[dataSize / 12];
         int j = 0;
         for (int i = storageAddress; i < storageAddress + dataSize; i+=12) {
-            int startAddr = (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true);
-            int endAddr   = (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true);
+            int startAddr = (int)parseByteValue(input, Settings.Endian.BIG, i  , 4, true) - offset;
+            int endAddr   = (int)parseByteValue(input, Settings.Endian.BIG, i+4, 4, true) - offset;
             int diff      = (int)parseByteValue(input, Settings.Endian.BIG, i+8, 4, true);
             if (j == 0 &&
                     startAddr == 0 &&

--- a/src/main/java/com/romraider/maps/TableSwitch.java
+++ b/src/main/java/com/romraider/maps/TableSwitch.java
@@ -54,8 +54,7 @@ public class TableSwitch extends Table1D {
 	    // if the result is  0: all the checksums matched
 	    // if the result is -1: all the checksums have been previously disabled
 	    if (super.getName().contains("Checksum Fix")) {
-	        int result = validateRomChecksum(getDataCell(0).getBinary(),
-	        		getStorageAddress(), getDataSize());
+			int result = validateRomChecksum(getDataCell(0).getBinary(), this);
 	        
 	        String message = MessageFormat.format(
 	                rb.getString("CHKSUMINVALID"), result, super.getName());

--- a/src/main/java/com/romraider/util/HexUtil.java
+++ b/src/main/java/com/romraider/util/HexUtil.java
@@ -159,10 +159,17 @@ public final class HexUtil {
      * @return integer value
      */
     public static int hexToInt(String input) {
+        int sign = 1;
+        //Detect negative sign, save it and remove from input
+        if (input.startsWith("-")){
+            sign = -1;
+            input = input.substring(1);
+        }
+        
         if (input.length() > 2 && input.substring(0, 2).equalsIgnoreCase("0x")) {
-            return Integer.parseInt(input.substring(2), 16);
+            return sign * Integer.parseInt(input.substring(2), 16);
         } else {
-            return Integer.parseInt(input, 16);
+            return sign * Integer.parseInt(input, 16);
         }
     }
 

--- a/src/main/java/com/romraider/util/HexUtil.java
+++ b/src/main/java/com/romraider/util/HexUtil.java
@@ -159,18 +159,7 @@ public final class HexUtil {
      * @return integer value
      */
     public static int hexToInt(String input) {
-        int sign = 1;
-        //Detect negative sign, save it and remove from input
-        if (input.startsWith("-")){
-            sign = -1;
-            input = input.substring(1);
-        }
-        
-        if (input.length() > 2 && input.substring(0, 2).equalsIgnoreCase("0x")) {
-            return sign * Integer.parseInt(input.substring(2), 16);
-        } else {
-            return sign * Integer.parseInt(input, 16);
-        }
+        return Integer.parseInt(input.replace("0x",""), 16);
     }
 
     /**


### PR DESCRIPTION
Added correct Subaru checksum processing when `offset` (in `romid` header) set to non-zero (checksums start and end addresses offset were ignored).
Corrected RomRaider edit stamp processing when `offset` set to non-zero.
Corrected Subaru checksum write to file when there's more than 1 `Checksum Fix` tables (the second and subsequent checksums were ignored).