### PR TITLE
Fix #241 Dataflow Simulations: Incorrect y-axis Interpolation

### DIFF
--- a/src/main/java/com/romraider/maps/Table1DView.java
+++ b/src/main/java/com/romraider/maps/Table1DView.java
@@ -1,6 +1,6 @@
 /*
  * RomRaider Open-Source Tuning, Logging and Reflashing
- * Copyright (C) 2006-2021 RomRaider.com
+ * Copyright (C) 2006-2025 RomRaider.com
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -279,6 +279,7 @@ public class Table1DView extends TableView {
             }
 
             int startIdx = data.length;
+            double currentErrorToLiveValue = Double.POSITIVE_INFINITY;
             for (int i = 0; i < data.length; i++) {
                 double currentValue = 0.0;
                 if(table.isStaticDataTable() && null != data[i].getStaticText()) {
@@ -290,14 +291,14 @@ public class Table1DView extends TableView {
                 } else {
                     currentValue = data[i].getDataCell().getRealValue();
                 }
-
-                if (liveValue == currentValue) {
-                    startIdx = i;
-                    break;
-                } else if (liveValue < currentValue){
-                    startIdx = i-1;
-                    break;
-                }
+                
+            	if(Math.abs(currentValue - liveValue) < currentErrorToLiveValue) 
+            	{
+            		currentErrorToLiveValue = Math.abs(currentValue - liveValue);
+            		startIdx = i;
+            		
+            		if(currentErrorToLiveValue <= 0.001) break;
+            	}
             }
 
             setLiveDataIndex(startIdx);

--- a/src/main/java/com/romraider/maps/Table3D.java
+++ b/src/main/java/com/romraider/maps/Table3D.java
@@ -572,13 +572,18 @@ public class Table3D extends Table {
 			}
 		}
 
-		double valueX1 = linearInterpolation(input_x, axisXData[startX].getRealValue(),
-				axisXData[endX].getRealValue(), tableData[startX][startY].getRealValue(),
-				tableData[endX][startY].getRealValue());
+		double valueX1 = linearInterpolation(input_x,
+			    axisXData[startX].getRealValue(),
+			    axisXData[endX].getRealValue(),
+			    tableData[startX][startY].getRealValue(),
+			    tableData[endX][startY].getRealValue());
 
-		double valueX2 = linearInterpolation(input_x, axisXData[startX].getRealValue(),
-				axisXData[endX].getRealValue(), tableData[endX][startY].getRealValue(),
-				tableData[endX][startY].getRealValue());
+		double valueX2 = linearInterpolation(input_x,
+			    axisXData[startX].getRealValue(),
+			    axisXData[endX].getRealValue(),
+			    tableData[startX][endY].getRealValue(),
+			    tableData[endX][endY].getRealValue());
+
 
 		return linearInterpolation(input_y, axisYData[startY].getRealValue(), axisYData[endY].getRealValue(),
 				valueX1, valueX2);


### PR DESCRIPTION
Hi,
this fixes #241. It also highlights the closest cell to the live value now instead of the one before it. If the live value is 59 and you are between cell 40 and 60, it would highlight cell 40 before. Now it highlights 60.

Regards
Robin